### PR TITLE
[Feat]#11 좋아요 구현

### DIFF
--- a/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/MyLikedCommunityResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/MyLikedCommunityResponse.java
@@ -1,25 +1,34 @@
 package tave.crezipsa.crezipsa.application.community.dto.response;
 
-import java.time.LocalDateTime;
-
+import static tave.crezipsa.crezipsa.application.community.usecase.LikeUseCaseImpl.*;
 import tave.crezipsa.crezipsa.domain.community.domain.Community;
+import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
 
 public record MyLikedCommunityResponse(
 	Long communityId,
+	CommunityField field,
 	String title,
 	String contentPreview,
 	long likeCount,
-	boolean liked,
-	LocalDateTime createdAt
+	long commentCount,
+	String relativeTime  // "40분 전", "3시간 전", "1일 전"
 ) {
-	public static MyLikedCommunityResponse of(Community community, long likeCount) {
+
+	public static MyLikedCommunityResponse of(
+		Community community,
+		long likeCount,
+		long commentCount
+	) {
 		return new MyLikedCommunityResponse(
 			community.getCommunityId(),
+			community.getField(),
 			community.getTitle(),
-			community.getContent().substring(0, Math.min(50, community.getContent().length())),
+			preview(community.getContent()),
 			likeCount,
-			true,
-			community.getCreatedAt()
+			commentCount,
+			convertToRelativeTime(community.getCreatedAt())
 		);
 	}
+
+
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/MyLikedCommunityResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/MyLikedCommunityResponse.java
@@ -1,0 +1,25 @@
+package tave.crezipsa.crezipsa.application.community.dto.response;
+
+import java.time.LocalDateTime;
+
+import tave.crezipsa.crezipsa.domain.community.domain.Community;
+
+public record MyLikedCommunityResponse(
+	Long communityId,
+	String title,
+	String contentPreview,
+	long likeCount,
+	boolean liked,
+	LocalDateTime createdAt
+) {
+	public static MyLikedCommunityResponse of(Community community, long likeCount) {
+		return new MyLikedCommunityResponse(
+			community.getCommunityId(),
+			community.getTitle(),
+			community.getContent().substring(0, Math.min(50, community.getContent().length())),
+			likeCount,
+			true,
+			community.getCreatedAt()
+		);
+	}
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCase.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCase.java
@@ -9,7 +9,7 @@ public interface LikeUseCase {
 
 	void like(Long userId, Long communityId);
 	void unlike(Long userId, Long communityId);
-	Long getLikeCount(Long community);
+	Long getLikeCount(Long communityId);
 	Slice<MyLikedCommunityResponse> getMyLikedCommunities(Long userId, Pageable pageable);
 
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCase.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCase.java
@@ -1,6 +1,9 @@
 package tave.crezipsa.crezipsa.application.community.usecase;
 
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+import tave.crezipsa.crezipsa.application.community.dto.response.MyLikedCommunityResponse;
 
 public interface LikeUseCase {
 

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCase.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCase.java
@@ -1,0 +1,12 @@
+package tave.crezipsa.crezipsa.application.community.usecase;
+
+import org.springframework.data.domain.Pageable;
+
+public interface LikeUseCase {
+
+	void like(Long userId, Long communityId);
+	void unlike(Long userId, Long communityId);
+	Long getLikeCount(Long community);
+	Slice<MyLikedCommunityResponse> getMyLikedCommunities(Long userId, Pageable pageable);
+
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCase.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCase.java
@@ -9,7 +9,7 @@ public interface LikeUseCase {
 
 	void like(Long userId, Long communityId);
 	void unlike(Long userId, Long communityId);
-	Long getLikeCount(Long communityId);
+	long getLikeCount(Long communityId);
 	Slice<MyLikedCommunityResponse> getMyLikedCommunities(Long userId, Pageable pageable);
 
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImpl.java
@@ -1,0 +1,66 @@
+package tave.crezipsa.crezipsa.application.community.usecase;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import tave.crezipsa.crezipsa.application.community.dto.response.MyLikedCommunityResponse;
+import tave.crezipsa.crezipsa.domain.community.domain.Community;
+import tave.crezipsa.crezipsa.domain.community.domain.Like;
+import tave.crezipsa.crezipsa.domain.community.domain.LikeId;
+import tave.crezipsa.crezipsa.domain.community.repository.CommentRepository;
+import tave.crezipsa.crezipsa.domain.community.repository.CommunityRepository;
+import tave.crezipsa.crezipsa.domain.community.repository.LikeRepository;
+import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
+import tave.crezipsa.crezipsa.global.exception.model.CommonException;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class LikeUseCaseImpl  implements LikeUseCase {
+
+	private final LikeRepository likeRepository;
+	private final CommunityRepository communityRepository;
+	private final CommentRepository commentRepository;
+
+	@Override
+	public void like(Long userId, Long communityId) {
+		LikeId likeId = new LikeId(userId, communityId);
+
+		if (likeRepository.existsById(likeId)) {
+			throw new CommonException(ErrorCode.ALREADY_LIKED);
+		}
+	}
+
+	@Override
+	public void unlike(Long userId, Long communityId) {
+		LikeId likeId = new LikeId(userId, communityId);
+
+		if (!likeRepository.existsById(likeId)) {
+			throw new CommonException(ErrorCode.NOT_LIKED);
+		}
+
+		likeRepository.delete(Like.of(userId, communityId));
+	}
+
+	@Override
+	public Long getLikeCount(Long communityId) {
+		return likeRepository.countByCommunityId(communityId);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public Slice<MyLikedCommunityResponse> getMyLikedCommunities(Long userId, Pageable pageable) {
+		return likeRepository.findAllByUserId(userId, pageable)
+			.map(like -> {
+				Community community = communityRepository.findById(like.getCommunityId())
+					.orElseThrow(() -> new CommonException(ErrorCode.COMMUNITY_NOT_FOUND));
+				long likeCount = likeRepository.countByCommunityId(like.getCommunityId());
+				long commentCount = commentRepository.countByCommunityId(community.getCommunityId());
+
+				return MyLikedCommunityResponse.of(community, likeCount, commentCount);
+			});
+	}
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImpl.java
@@ -31,20 +31,32 @@ public class LikeUseCaseImpl  implements LikeUseCase {
 	public void like(Long userId, Long communityId) {
 		LikeId likeId = new LikeId(userId, communityId);
 
+		Community community = communityRepository.findById(communityId)
+			.orElseThrow(() -> new CommonException(ErrorCode.COMMUNITY_NOT_FOUND));
+
 		if (likeRepository.existsById(likeId)) {
 			throw new CommonException(ErrorCode.ALREADY_LIKED);
 		}
+
+		likeRepository.save(new Like(userId, communityId));
+		community.increaseLikeCount();
+
 	}
 
 	@Override
 	public void unlike(Long userId, Long communityId) {
 		LikeId likeId = new LikeId(userId, communityId);
 
+		Community community = communityRepository.findById(communityId)
+			.orElseThrow(() -> new CommonException(ErrorCode.COMMUNITY_NOT_FOUND));
+
 		if (!likeRepository.existsById(likeId)) {
 			throw new CommonException(ErrorCode.NOT_LIKED);
 		}
 
 		likeRepository.delete(Like.of(userId, communityId));
+		community.decreaseLikeCount();
+
 	}
 
 	@Override

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImpl.java
@@ -1,5 +1,7 @@
 package tave.crezipsa.crezipsa.application.community.usecase;
 
+import java.time.LocalDateTime;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -62,5 +64,21 @@ public class LikeUseCaseImpl  implements LikeUseCase {
 
 				return MyLikedCommunityResponse.of(community, likeCount, commentCount);
 			});
+	}
+
+	public static String preview(String content) {
+		return content.substring(0, Math.min(50, content.length()));
+	}
+
+	public static String convertToRelativeTime(LocalDateTime createdAt) {
+		LocalDateTime now = LocalDateTime.now();
+		long minutes = java.time.Duration.between(createdAt, now).toMinutes();
+		long hours = minutes / 60;
+		long days = hours / 24;
+
+		if (minutes < 1) return "방금 전";
+		if (minutes < 60) return minutes + "분 전";
+		if (hours < 24) return hours + "시간 전";
+		return days + "일 전";
 	}
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImpl.java
@@ -48,7 +48,7 @@ public class LikeUseCaseImpl  implements LikeUseCase {
 	}
 
 	@Override
-	public Long getLikeCount(Long communityId) {
+	public long getLikeCount(Long communityId) {
 		return likeRepository.countByCommunityId(communityId);
 	}
 

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImpl.java
@@ -58,28 +58,30 @@ public class LikeUseCaseImpl  implements LikeUseCase {
 		Community community = communityRepository.findById(communityId)
 			.orElseThrow(() -> new CommonException(ErrorCode.COMMUNITY_NOT_FOUND));
 
-		if (!likeRepository.existsById(likeId)) {
+		Like like = likeRepository.findById(likeId)
+			.orElseThrow(() -> new CommonException(ErrorCode.NOT_LIKED));
+
+		if (!like.isLiked()) {
 			throw new CommonException(ErrorCode.NOT_LIKED);
 		}
-
-		likeRepository.delete(Like.of(userId, communityId));
+		like.unlike();
 		community.decreaseLikeCount();
 
 	}
 
 	@Override
 	public long getLikeCount(Long communityId) {
-		return likeRepository.countByCommunityId(communityId);
+		return likeRepository.countByCommunityIdAndIsLikedTrue(communityId);
 	}
 
 	@Override
 	@Transactional(readOnly = true)
 	public Slice<MyLikedCommunityResponse> getMyLikedCommunities(Long userId, Pageable pageable) {
-		return likeRepository.findAllByUserId(userId, pageable)
+		return likeRepository.findAllByUserIdAndIsLikedTrue(userId, pageable)
 			.map(like -> {
 				Community community = communityRepository.findById(like.getCommunityId())
 					.orElseThrow(() -> new CommonException(ErrorCode.COMMUNITY_NOT_FOUND));
-				long likeCount = likeRepository.countByCommunityId(like.getCommunityId());
+				long likeCount = likeRepository.countByCommunityIdAndIsLikedTrue(like.getCommunityId());
 				long commentCount = commentRepository.countByCommunityId(community.getCommunityId());
 
 				return MyLikedCommunityResponse.of(community, likeCount, commentCount);

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImpl.java
@@ -34,13 +34,21 @@ public class LikeUseCaseImpl  implements LikeUseCase {
 		Community community = communityRepository.findById(communityId)
 			.orElseThrow(() -> new CommonException(ErrorCode.COMMUNITY_NOT_FOUND));
 
-		if (likeRepository.existsById(likeId)) {
-			throw new CommonException(ErrorCode.ALREADY_LIKED);
+		Like like = likeRepository.findById(likeId).orElse(null);
+
+		if (like == null) {
+			likeRepository.save(Like.of(userId, communityId));
+			community.increaseLikeCount();
+			return;
 		}
 
-		likeRepository.save(new Like(userId, communityId));
-		community.increaseLikeCount();
-
+		if (like.isLiked()) {
+			like.unlike();
+			community.decreaseLikeCount();
+		} else {
+			like.like();
+			community.increaseLikeCount();
+		}
 	}
 
 	@Override

--- a/src/main/java/tave/crezipsa/crezipsa/domain/community/domain/Like.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/community/domain/Like.java
@@ -3,6 +3,7 @@ package tave.crezipsa.crezipsa.domain.community.domain;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,6 +18,7 @@ import tave.crezipsa.crezipsa.global.common.entity.BaseEntity;
 @AllArgsConstructor
 @Builder
 @IdClass(LikeId.class) // 복합키 정의 클래스 지정
+@Table(name = "community_like")
 public class Like extends BaseEntity {
 
 	@Id

--- a/src/main/java/tave/crezipsa/crezipsa/domain/community/domain/Like.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/community/domain/Like.java
@@ -27,11 +27,25 @@ public class Like extends BaseEntity {
 	@Id
 	private Long communityId;
 
+	@Builder.Default
+	private boolean isLiked = false;
+
 	public static Like of(Long userId, Long communityId) {
-		return Like.builder()
+
+		Like like = Like.builder()
 			.userId(userId)
 			.communityId(communityId)
 			.build();
+		like.like();
+
+		return like;
 	}
 
+	public void like() {
+		this.isLiked = true;
+	}
+
+	public void unlike() {
+		this.isLiked = false;
+	}
 }

--- a/src/main/java/tave/crezipsa/crezipsa/domain/community/repository/CommentRepository.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/community/repository/CommentRepository.java
@@ -14,5 +14,6 @@ public interface CommentRepository {
 	List<Comment> findByUserId(Long userId);
 	List<Comment> findByParentId(Long parentId);
 	void delete(Comment comment);
-
+	long countByCommunityId(Long communityId);
 }
+

--- a/src/main/java/tave/crezipsa/crezipsa/domain/community/repository/LikeRepository.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/community/repository/LikeRepository.java
@@ -12,5 +12,7 @@ public interface LikeRepository {
 	Optional<Like> findById(LikeId likedId);
 	void delete(Like like);
 	boolean existsById(LikeId likedId);
-
+	boolean existsByUserIdAndCommunityId(Long userId, Long communityId);
+	void deleteByUserIdAndCommunityId(Long userId, Long communityId);
+	long countByCommunityId(Long communityId);
 }

--- a/src/main/java/tave/crezipsa/crezipsa/domain/community/repository/LikeRepository.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/community/repository/LikeRepository.java
@@ -3,6 +3,9 @@ package tave.crezipsa.crezipsa.domain.community.repository;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import tave.crezipsa.crezipsa.domain.community.domain.Like;
 import tave.crezipsa.crezipsa.domain.community.domain.LikeId;
 
@@ -15,4 +18,6 @@ public interface LikeRepository {
 	boolean existsByUserIdAndCommunityId(Long userId, Long communityId);
 	void deleteByUserIdAndCommunityId(Long userId, Long communityId);
 	long countByCommunityId(Long communityId);
+	Page<Like> findAllByUserId(Long userId, Pageable pageable);
+
 }

--- a/src/main/java/tave/crezipsa/crezipsa/domain/community/repository/LikeRepository.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/community/repository/LikeRepository.java
@@ -17,7 +17,8 @@ public interface LikeRepository {
 	boolean existsById(LikeId likedId);
 	boolean existsByUserIdAndCommunityId(Long userId, Long communityId);
 	void deleteByUserIdAndCommunityId(Long userId, Long communityId);
-	long countByCommunityId(Long communityId);
-	Page<Like> findAllByUserId(Long userId, Pageable pageable);
+	long countByCommunityIdAndIsLikedTrue(Long communityId);
+	Page<Like> findAllByUserIdAndIsLikedTrue(Long userId, Pageable pageable);
+
 
 }

--- a/src/main/java/tave/crezipsa/crezipsa/global/config/SecurityConfig.java
+++ b/src/main/java/tave/crezipsa/crezipsa/global/config/SecurityConfig.java
@@ -31,6 +31,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()// 로그인 관련 API는 인증 없이 접근 가능
                         .requestMatchers("/api/user/signUp").permitAll()
+                        .requestMatchers("/api/likes/**").permitAll()
                         .anyRequest().authenticated()             // 그 외는 인증 필요
                 )
 

--- a/src/main/java/tave/crezipsa/crezipsa/global/exception/code/ErrorCode.java
+++ b/src/main/java/tave/crezipsa/crezipsa/global/exception/code/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode implements BaseErrorCode {
 	INVALID_PARENT_COMMUNITY(400, "C4005", "대댓글은 동일한 게시글 내에서만 달 수 있습니다"),
 	COMMENT_NOT_FOUND(404, "C40402", "해당 댓글을 찾을 수 없습니다."),
 	ALREADY_LIKED(400, "C40002", "이미 좋아요를 누른 게시글입니다."),
+	NOT_LIKED(400,"C40003", "좋아요를 누르지 않은 글입니다."),
 	UNAUTHORIZED_COMMUNITY(404, "C40403", "게시글 권한이 없습니다"),
 	UNAUTHORIZED_COMMENT(404, "C40404", "댓글 권한이 없습니다"),
 

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/community/repository/CommentJpaRepository.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/community/repository/CommentJpaRepository.java
@@ -11,5 +11,5 @@ public interface CommentJpaRepository extends JpaRepository<Comment, Long> {
 	List<Comment> findByCommunityId(Long CommunityId);
 	List<Comment> findByUserId(Long userId);
 	List<Comment> findByParentId(Long parentId);
-
+	long countByCommunityId(Long communityId);
 }

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/community/repository/CommentRepositoryImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/community/repository/CommentRepositoryImpl.java
@@ -45,4 +45,8 @@ public class CommentRepositoryImpl implements CommentRepository {
 		return commentJpaRepository.findByParentId(parentId);
 	}
 
+	@Override
+	public long countByCommunityId(Long communityId) {
+		return commentJpaRepository.countByCommunityId(communityId);
+	}
 }

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/community/repository/LikeJpaRepository.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/community/repository/LikeJpaRepository.java
@@ -7,4 +7,7 @@ import tave.crezipsa.crezipsa.domain.community.domain.LikeId;
 
 public interface LikeJpaRepository extends JpaRepository<Like, LikeId> {
 	boolean existsById(LikeId likeId);
+	boolean existsByUserIdAndCommunityId(Long userId, Long communityId);
+	void deleteByUserIdAndCommunityId(Long userId, Long communityId);
+	long countByCommunityId(Long communityId);
 }

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/community/repository/LikeJpaRepository.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/community/repository/LikeJpaRepository.java
@@ -1,5 +1,7 @@
 package tave.crezipsa.crezipsa.infrastructure.community.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import tave.crezipsa.crezipsa.domain.community.domain.Like;
@@ -10,4 +12,6 @@ public interface LikeJpaRepository extends JpaRepository<Like, LikeId> {
 	boolean existsByUserIdAndCommunityId(Long userId, Long communityId);
 	void deleteByUserIdAndCommunityId(Long userId, Long communityId);
 	long countByCommunityId(Long communityId);
+	Page<Like> findAllByUserId(Long userId, Pageable pageable);
+
 }

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/community/repository/LikeJpaRepository.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/community/repository/LikeJpaRepository.java
@@ -11,7 +11,8 @@ public interface LikeJpaRepository extends JpaRepository<Like, LikeId> {
 	boolean existsById(LikeId likeId);
 	boolean existsByUserIdAndCommunityId(Long userId, Long communityId);
 	void deleteByUserIdAndCommunityId(Long userId, Long communityId);
-	long countByCommunityId(Long communityId);
-	Page<Like> findAllByUserId(Long userId, Pageable pageable);
+	long countByCommunityIdAndIsLikedTrue(Long communityId);
+	Page<Like> findAllByUserIdAndIsLikedTrue(Long userId, Pageable pageable);
+
 
 }

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/community/repository/LikeRepositoryImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/community/repository/LikeRepositoryImpl.java
@@ -34,4 +34,19 @@ public class LikeRepositoryImpl implements LikeRepository {
 	public boolean existsById(LikeId likeId) {
 		return likeJpaRepository.existsById(likeId);
 	}
+
+	@Override
+	public boolean existsByUserIdAndCommunityId(Long userId, Long communityId) {
+		return likeJpaRepository.existsByUserIdAndCommunityId(userId, communityId);
+	}
+
+	@Override
+	public void deleteByUserIdAndCommunityId(Long userId, Long communityId) {
+		likeJpaRepository.deleteByUserIdAndCommunityId(userId, communityId);
+	}
+
+	@Override
+	public long countByCommunityId(Long communityId) {
+		return likeJpaRepository.countByCommunityId(communityId);
+	}
 }

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/community/repository/LikeRepositoryImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/community/repository/LikeRepositoryImpl.java
@@ -2,6 +2,8 @@ package tave.crezipsa.crezipsa.infrastructure.community.repository;
 
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import lombok.RequiredArgsConstructor;
@@ -48,5 +50,10 @@ public class LikeRepositoryImpl implements LikeRepository {
 	@Override
 	public long countByCommunityId(Long communityId) {
 		return likeJpaRepository.countByCommunityId(communityId);
+	}
+
+	@Override
+	public Page<Like> findAllByUserId(Long userId, Pageable pageable) {
+		return likeJpaRepository.findAllByUserId(userId, pageable);
 	}
 }

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/community/repository/LikeRepositoryImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/community/repository/LikeRepositoryImpl.java
@@ -48,12 +48,12 @@ public class LikeRepositoryImpl implements LikeRepository {
 	}
 
 	@Override
-	public long countByCommunityId(Long communityId) {
-		return likeJpaRepository.countByCommunityId(communityId);
+	public long countByCommunityIdAndIsLikedTrue(Long communityId) {
+		return likeJpaRepository.countByCommunityIdAndIsLikedTrue(communityId);
 	}
 
 	@Override
-	public Page<Like> findAllByUserId(Long userId, Pageable pageable) {
-		return likeJpaRepository.findAllByUserId(userId, pageable);
+	public Page<Like> findAllByUserIdAndIsLikedTrue(Long userId, Pageable pageable) {
+		return likeJpaRepository.findAllByUserIdAndIsLikedTrue(userId, pageable);
 	}
 }

--- a/src/main/java/tave/crezipsa/crezipsa/presentation/community/controller/LikeController.java
+++ b/src/main/java/tave/crezipsa/crezipsa/presentation/community/controller/LikeController.java
@@ -1,0 +1,54 @@
+package tave.crezipsa.crezipsa.presentation.community.controller;
+
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import tave.crezipsa.crezipsa.application.community.dto.response.MyLikedCommunityResponse;
+import tave.crezipsa.crezipsa.application.community.usecase.LikeUseCase;
+import tave.crezipsa.crezipsa.domain.user.entity.User;
+import tave.crezipsa.crezipsa.global.common.dto.GlobalResponseDto;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/likes")
+public class LikeController {
+
+	private final LikeUseCase likeUseCase;
+
+	@PostMapping("/{communityId}")
+	public GlobalResponseDto<Void> like(@AuthenticationPrincipal User user, @PathVariable Long communityId) {
+		likeUseCase.like(user.getUserId(), communityId);
+		return GlobalResponseDto.success();
+	}
+
+	@DeleteMapping("/{communityId}")
+	public GlobalResponseDto<Void> unlike(@AuthenticationPrincipal User user, @PathVariable Long communityId) {
+		likeUseCase.unlike(user.getUserId(), communityId);
+		return GlobalResponseDto.success();
+	}
+
+	@GetMapping("/{communityId}")
+	public GlobalResponseDto<Long> getLikeCount(@PathVariable Long communityId) {
+		return GlobalResponseDto.success(likeUseCase.getLikeCount(communityId));
+	}
+
+	@GetMapping("/me")
+	public GlobalResponseDto<List<MyLikedCommunityResponse>> getMyLikedCommunities(
+		@AuthenticationPrincipal User user,
+		Pageable pageable
+	) {
+		var slice = likeUseCase.getMyLikedCommunities(user.getUserId(), pageable);
+		return GlobalResponseDto.success(slice.getContent());
+	}
+
+
+}

--- a/src/main/java/tave/crezipsa/crezipsa/presentation/community/controller/LikeController.java
+++ b/src/main/java/tave/crezipsa/crezipsa/presentation/community/controller/LikeController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
@@ -23,7 +24,7 @@ import tave.crezipsa.crezipsa.global.common.dto.GlobalResponseDto;
 public class LikeController {
 
 	private final LikeUseCase likeUseCase;
-
+/*
 	@PostMapping("/{communityId}")
 	public GlobalResponseDto<Void> like(@AuthenticationPrincipal User user, @PathVariable Long communityId) {
 		likeUseCase.like(user.getUserId(), communityId);
@@ -49,6 +50,31 @@ public class LikeController {
 		var slice = likeUseCase.getMyLikedCommunities(user.getUserId(), pageable);
 		return GlobalResponseDto.success(slice.getContent());
 	}
+*/
+    @PostMapping("/{communityId}")
+	public GlobalResponseDto<Void> like(@RequestParam Long userId, @PathVariable Long communityId) {
+		likeUseCase.like(userId, communityId);
+		return GlobalResponseDto.success();
+	}
 
+	@DeleteMapping("/{communityId}")
+	public GlobalResponseDto<Void> unlike(@RequestParam Long userId, @PathVariable Long communityId) {
+		likeUseCase.unlike(userId, communityId);
+		return GlobalResponseDto.success();
+	}
+
+	@GetMapping("/{communityId}")
+	public GlobalResponseDto<Long> getLikeCount(@PathVariable Long communityId) {
+		return GlobalResponseDto.success(likeUseCase.getLikeCount(communityId));
+	}
+
+	@GetMapping("/me")
+	public GlobalResponseDto<List<MyLikedCommunityResponse>> getMyLikedCommunities(
+		@RequestParam Long userId,
+		Pageable pageable
+	) {
+		var slice = likeUseCase.getMyLikedCommunities(userId, pageable);
+		return GlobalResponseDto.success(slice.getContent());
+	}
 
 }


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
커뮤니티에 달 수 있는 좋아요를 구현했습니다. 

ERD 구상 시 , 복합 키로 구성된 Like 테이블을 JPA로 바로 구현하는 것은 한계가 있어 Like 엔티티와 복합키를 정의하는 클래스인 LikeId 클래스를 생성해서 구현하였습니다.

JPA에서 복합키를 구성하는 방법은 두 가지가 존재합니다.
1. @IdClass
2. @EmbeddedId
저희는 구조 상 userId, communityId 두 개로 깔끔하게 분리되기 때문에 1번이 더 직관적이라 생각하였습니다.

 userId, communityId가 PK이므로 구조 자체적으로 좋아요 중복을 해결할 수 있기는 합니다.

현재 회원가입 관련 API 기능이 검토중이므로 테스트는 SecurityContextHolder에서 유저 인증객체를 가져온 것이 아닌, 임의로 UserId를 Param해서 넣어줬습니다.

구현한 API는 다음과 같습니다.
좋아요 달기, 좋아요 취소 , 글의 좋아요 갯수 조회, 내가 좋아요한 글들 불러오기 등이 있습니다.
## 🔍 참고 사항
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->

다음 PR에서 컨트롤러에 매개변수 userId를  SecurityContextHolder로 가져와서 변경해두겠습니다.

## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
좋아요를 이미 누른 글에 다시 좋아요를 누를경우 ( 예외처리) 
<img width="699" height="462" alt="스크린샷 2025-11-23 오전 11 21 56" src="https://github.com/user-attachments/assets/5d65f857-21e7-4a42-9431-712e74f076d2" />

좋아요를 누르고 난 뒤, DB 상태
<img width="758" height="424" alt="스크린샷 2025-11-23 오전 11 21 38" src="https://github.com/user-attachments/assets/b5149ec3-a557-44af-b6ce-52642c5cf0e3" />

좋아요 삭제
<img width="736" height="505" alt="스크린샷 2025-11-23 오전 11 22 17" src="https://github.com/user-attachments/assets/56a7d8b8-a173-48c1-b863-cbc39cc00d3c" />

좋아요 삭제 후 DB 상태 
<img width="600" height="344" alt="스크린샷 2025-11-23 오전 11 22 23" src="https://github.com/user-attachments/assets/294c8dad-dd36-4f11-a730-c18b1596924d" />


내가 좋아요 누른 글들 (내 좋아요함 전용 API)
<img width="766" height="560" alt="스크린샷 2025-11-23 오전 11 30 36" src="https://github.com/user-attachments/assets/997a4498-abe4-475c-a293-7e6000162c1b" />
 

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인