### PR TITLE
[Refactor] #13 유저 파라미터 변경

### DIFF
--- a/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/CommunityDetailResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/CommunityDetailResponse.java
@@ -1,0 +1,32 @@
+package tave.crezipsa.crezipsa.application.community.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import tave.crezipsa.crezipsa.domain.community.domain.Community;
+import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
+
+public record CommunityDetailResponse(
+	Long communityId,
+	String title,
+	String content,
+	CommunityField field,
+	List<String> imageUrls,
+	Long writerId,
+	Long likeCount,
+	LocalDateTime createdAt
+) {
+
+	public static CommunityDetailResponse from(Community community) {
+		return new CommunityDetailResponse(
+			community.getCommunityId(),
+			community.getTitle(),
+			community.getContent(),
+			community.getField(),
+			community.getImageUrls(),
+			community.getWriterId(),
+			community.getLikeCount(),
+			community.getCreatedAt()
+		);
+	}
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/CommunityDetailResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/CommunityDetailResponse.java
@@ -1,5 +1,7 @@
 package tave.crezipsa.crezipsa.application.community.dto.response;
 
+import static tave.crezipsa.crezipsa.application.community.usecase.LikeUseCaseImpl.*;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -12,26 +14,18 @@ public record CommunityDetailResponse(
 	String content,
 	CommunityField field,
 	List<String> imageUrls,
-
-	// 작성자 정보
 	Long writerId,
-	String writerNickname,
-	String writerProfileImage,
-
-	// 상태 정보
-	boolean isLikedByMe,
-	boolean isMine,
-
 	long likeCount,
 	long commentCount,
-
 	String relativeTime,
-
-	// 댓글 목록 전체
 	List<CommentResponse> comments
 ) {
 
-	public static CommunityDetailResponse from(Community community ,long commentCount) {
+	public static CommunityDetailResponse from(
+		Community community,
+		long commentCount,
+		List<CommentResponse> comments
+	) {
 		return new CommunityDetailResponse(
 			community.getCommunityId(),
 			community.getTitle(),
@@ -41,7 +35,8 @@ public record CommunityDetailResponse(
 			community.getWriterId(),
 			community.getLikeCount(),
 			commentCount,
-			community.getCreatedAt()
+			convertToRelativeTime(community.getCreatedAt()),
+			comments
 		);
 	}
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/CommunityDetailResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/CommunityDetailResponse.java
@@ -12,12 +12,26 @@ public record CommunityDetailResponse(
 	String content,
 	CommunityField field,
 	List<String> imageUrls,
+
+	// 작성자 정보
 	Long writerId,
-	Long likeCount,
-	LocalDateTime createdAt
+	String writerNickname,
+	String writerProfileImage,
+
+	// 상태 정보
+	boolean isLikedByMe,
+	boolean isMine,
+
+	long likeCount,
+	long commentCount,
+
+	String relativeTime,
+
+	// 댓글 목록 전체
+	List<CommentResponse> comments
 ) {
 
-	public static CommunityDetailResponse from(Community community) {
+	public static CommunityDetailResponse from(Community community ,long commentCount) {
 		return new CommunityDetailResponse(
 			community.getCommunityId(),
 			community.getTitle(),
@@ -26,6 +40,7 @@ public record CommunityDetailResponse(
 			community.getImageUrls(),
 			community.getWriterId(),
 			community.getLikeCount(),
+			commentCount,
 			community.getCreatedAt()
 		);
 	}

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/CommunityResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/CommunityResponse.java
@@ -1,32 +1,6 @@
 package tave.crezipsa.crezipsa.application.community.dto.response;
 
-import java.time.LocalDateTime;
-import java.util.List;
+public record CommunityResponse() {
+	// 글 생성이나 ,수정시 반환되는 DTO 전용
 
-import tave.crezipsa.crezipsa.domain.community.domain.Community;
-import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
-
-public record CommunityResponse(
-	Long communityId,
-	String title,
-	String content,
-	CommunityField field,
-	List<String> imageUrls,
-	Long writerId,
-	Long likeCount,
-	LocalDateTime createdAt
-) {
-
-	public static CommunityResponse from(Community community) {
-		return new CommunityResponse(
-			community.getCommunityId(),
-			community.getTitle(),
-			community.getContent(),
-			community.getField(),
-			community.getImageUrls(),
-			community.getWriterId(),
-			community.getLikeCount(),
-			community.getCreatedAt()
-		);
-	}
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/CommunityResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/CommunityResponse.java
@@ -3,36 +3,30 @@ package tave.crezipsa.crezipsa.application.community.dto.response;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
 import tave.crezipsa.crezipsa.domain.community.domain.Community;
 import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
 
-@Getter
-@AllArgsConstructor
-@Builder
-public class CommunityResponse {
-
-	private Long communityId;
-	private String title;
-	private String content;
-	private CommunityField field;
-	private List<String> imageUrls;
-	private Long writerId;
-	private Long likeCount;
-	private LocalDateTime createdAt;
+public record CommunityResponse(
+	Long communityId,
+	String title,
+	String content,
+	CommunityField field,
+	List<String> imageUrls,
+	Long writerId,
+	Long likeCount,
+	LocalDateTime createdAt
+) {
 
 	public static CommunityResponse from(Community community) {
-		return CommunityResponse.builder()
-			.communityId(community.getCommunityId())
-			.title(community.getTitle())
-			.content(community.getContent())
-			.field(community.getField())
-			.imageUrls(community.getImageUrls())
-			.writerId(community.getWriterId())
-			.likeCount(community.getLikeCount())
-			.createdAt(community.getCreatedAt())
-			.build();
+		return new CommunityResponse(
+			community.getCommunityId(),
+			community.getTitle(),
+			community.getContent(),
+			community.getField(),
+			community.getImageUrls(),
+			community.getWriterId(),
+			community.getLikeCount(),
+			community.getCreatedAt()
+		);
 	}
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/CommunityResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/CommunityResponse.java
@@ -1,6 +1,21 @@
 package tave.crezipsa.crezipsa.application.community.dto.response;
 
-public record CommunityResponse() {
-	// 글 생성이나 ,수정시 반환되는 DTO 전용
+import tave.crezipsa.crezipsa.domain.community.domain.Community;
+import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
+
+public record CommunityResponse(
+	Long communityId,
+	CommunityField field,
+	String title,
+	String content) {
+
+	public static CommunityResponse of(Community community) {
+		return new CommunityResponse(
+			community.getCommunityId(),
+			community.getField(),
+			community.getTitle(),
+			community.getContent()
+		);
+	}
 
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/CommunitySummaryResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/CommunitySummaryResponse.java
@@ -1,0 +1,38 @@
+package tave.crezipsa.crezipsa.application.community.dto.response;
+
+import tave.crezipsa.crezipsa.application.community.usecase.LikeUseCaseImpl;
+import tave.crezipsa.crezipsa.domain.community.domain.Community;
+import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
+
+public record CommunitySummaryResponse(
+	Long communityId,
+	CommunityField field,
+	String title,
+	String contentPreview,
+	long likeCount,
+	long commentCount,
+	String relativeTime,
+	String thumbnailUrl
+) {
+
+	public static CommunitySummaryResponse of(
+		Community community,
+		long likeCount,
+		long commentCount
+	) {
+		String thumbnail = (community.getImageUrls() != null && !community.getImageUrls().isEmpty())
+			? community.getImageUrls().get(0)
+			: null;
+
+		return new CommunitySummaryResponse(
+			community.getCommunityId(),
+			community.getField(),
+			community.getTitle(),
+			LikeUseCaseImpl.preview(community.getContent()),
+			likeCount,
+			commentCount,
+			LikeUseCaseImpl.convertToRelativeTime(community.getCreatedAt()),
+			thumbnail
+		);
+	}
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/MyCommentResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/MyCommentResponse.java
@@ -1,0 +1,26 @@
+package tave.crezipsa.crezipsa.application.community.dto.response;
+
+import static tave.crezipsa.crezipsa.application.community.usecase.LikeUseCaseImpl.*;
+
+import tave.crezipsa.crezipsa.domain.community.domain.Community;
+import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
+
+public record MyCommentResponse(
+	Long communityId,
+	CommunityField field,
+	String title,
+	String contentPreview,
+	String relativeTime  // "40분 전", "3시간 전", "1일 전"
+) {
+
+	public static MyCommentResponse of(Community community) {
+		return new MyCommentResponse(
+			community.getCommunityId(),
+			community.getField(),
+			community.getTitle(),
+			preview(community.getContent()),
+			convertToRelativeTime(community.getCreatedAt())
+		);
+
+	}
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/MyCommunityResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/MyCommunityResponse.java
@@ -1,0 +1,39 @@
+package tave.crezipsa.crezipsa.application.community.dto.response;
+
+import static tave.crezipsa.crezipsa.application.community.usecase.LikeUseCaseImpl.*;
+
+import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
+import tave.crezipsa.crezipsa.domain.community.domain.Community;
+
+public record MyCommunityResponse(
+	Long communityId,
+	CommunityField field,
+	String title,
+	String contentPreview,
+	long likeCount,
+	long commentCount,
+	String relativeTime,
+	String thumbnailUrl
+) {
+
+	public static MyCommunityResponse of(
+		Community community,
+		long likeCount,
+		long commentCount
+	) {
+		String thumbnail = (community.getImageUrls() != null && !community.getImageUrls().isEmpty())
+			? community.getImageUrls().get(0)
+			: null;
+
+		return new MyCommunityResponse(
+			community.getCommunityId(),
+			community.getField(),
+			community.getTitle(),
+			preview(community.getContent()),
+			likeCount,
+			commentCount,
+			convertToRelativeTime(community.getCreatedAt()),
+			thumbnail
+		);
+	}
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/MyLikedCommunityResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/MyLikedCommunityResponse.java
@@ -11,7 +11,8 @@ public record MyLikedCommunityResponse(
 	String contentPreview,
 	long likeCount,
 	long commentCount,
-	String relativeTime  // "40분 전", "3시간 전", "1일 전"
+	String relativeTime,  // "40분 전", "3시간 전", "1일 전"
+	String thumbnailUrl
 ) {
 
 	public static MyLikedCommunityResponse of(
@@ -19,6 +20,10 @@ public record MyLikedCommunityResponse(
 		long likeCount,
 		long commentCount
 	) {
+		String thumbnail = (community.getImageUrls() != null && !community.getImageUrls().isEmpty())
+			? community.getImageUrls().get(0)
+			: null;
+
 		return new MyLikedCommunityResponse(
 			community.getCommunityId(),
 			community.getField(),
@@ -26,7 +31,8 @@ public record MyLikedCommunityResponse(
 			preview(community.getContent()),
 			likeCount,
 			commentCount,
-			convertToRelativeTime(community.getCreatedAt())
+			convertToRelativeTime(community.getCreatedAt()),
+			thumbnail
 		);
 	}
 

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/CommentUseCaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/CommentUseCaseImpl.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommentCreateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommentUpdateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.response.CommentResponse;
+import tave.crezipsa.crezipsa.application.community.dto.response.MyCommentResponse;
 import tave.crezipsa.crezipsa.application.community.mapper.CommentMapper;
 import tave.crezipsa.crezipsa.domain.community.domain.Comment;
 import tave.crezipsa.crezipsa.domain.community.domain.Community;
@@ -116,26 +117,16 @@ public class CommentUseCaseImpl implements  CommentUsecase {
 	}
 
 	@Override
-	public List<CommentResponse> getMyComments(Long userId) {
+	public List<MyCommentResponse> getMyComments(Long userId) {
 
 		List<Comment> myComments = commentRepository.findByUserId(userId);
 
 		return myComments.stream()
 			.map(comment -> {
-				User writer = findUserOrThrow(comment.getUserId());
+				Community community = communityRepository.findById(comment.getCommunityId())
+					.orElseThrow(() -> new CommonException(ErrorCode.COMMUNITY_NOT_FOUND));
 
-				return new CommentResponse(
-					comment.getCommentId(),
-					comment.getCommunityId(),
-					comment.getParentId(),
-					comment.getUserId(),
-					writer.getNickName(),
-					writer.getProfileImageUrl(),
-					comment.isDeleted(),
-					comment.getContent(),
-					comment.getCreatedAt(),
-					List.of()
-				);
+				return MyCommentResponse.of(community);
 			})
 			.toList();
 	}

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/CommentUsecase.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/CommentUsecase.java
@@ -5,6 +5,7 @@ import java.util.List;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommentCreateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommentUpdateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.response.CommentResponse;
+import tave.crezipsa.crezipsa.application.community.dto.response.MyCommentResponse;
 
 public interface CommentUsecase {
 
@@ -12,7 +13,7 @@ public interface CommentUsecase {
 	CommentResponse updateComment(Long commentId, Long userId, CommentUpdateRequest request);
 	void deleteComment(Long commentId, Long userId);
 	List<CommentResponse> getComments(Long communityId);
-	List<CommentResponse> getMyComments(Long userId);
+	List<MyCommentResponse> getMyComments(Long userId);
 
 
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/CommunityUseCase.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/CommunityUseCase.java
@@ -5,6 +5,7 @@ import java.util.List;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommunityCreateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommunityUpdateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.response.CommunityResponse;
+import tave.crezipsa.crezipsa.application.community.dto.response.MyCommunityResponse;
 import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
 
 public interface CommunityUseCase {
@@ -13,7 +14,7 @@ public interface CommunityUseCase {
 	CommunityResponse updateCommunity(Long userId,Long communityId, CommunityUpdateRequest communityUpdateRequest);
 	CommunityResponse getCommunity(Long communityId);
 	List<CommunityResponse> getAllCommunities();
-	List<CommunityResponse> getMyCommunities(Long userId);
+	List<MyCommunityResponse> getMyCommunities(Long userId);
 	List<CommunityResponse> getCommunitiesByField(CommunityField field);
 	void deleteCommunity(Long userId,Long communityId);
 

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/CommunityUseCase.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/CommunityUseCase.java
@@ -4,7 +4,9 @@ import java.util.List;
 
 import tave.crezipsa.crezipsa.application.community.dto.request.CommunityCreateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommunityUpdateRequest;
+import tave.crezipsa.crezipsa.application.community.dto.response.CommunityDetailResponse;
 import tave.crezipsa.crezipsa.application.community.dto.response.CommunityResponse;
+import tave.crezipsa.crezipsa.application.community.dto.response.CommunitySummaryResponse;
 import tave.crezipsa.crezipsa.application.community.dto.response.MyCommunityResponse;
 import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
 
@@ -12,10 +14,10 @@ public interface CommunityUseCase {
 
 	CommunityResponse createCommunity(Long userId, CommunityCreateRequest communityCreateRequest);
 	CommunityResponse updateCommunity(Long userId,Long communityId, CommunityUpdateRequest communityUpdateRequest);
-	CommunityResponse getCommunity(Long communityId);
-	List<CommunityResponse> getAllCommunities();
+	CommunityDetailResponse getCommunity(Long communityId);
+	List<CommunitySummaryResponse> getAllCommunities();
 	List<MyCommunityResponse> getMyCommunities(Long userId);
-	List<CommunityResponse> getCommunitiesByField(CommunityField field);
+	List<CommunitySummaryResponse> getCommunitiesByField(CommunityField field);
 	void deleteCommunity(Long userId,Long communityId);
 
 

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/CommunityUseCaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/CommunityUseCaseImpl.java
@@ -49,7 +49,7 @@ public class CommunityUseCaseImpl implements CommunityUseCase {
 	}
 
 	@Override
-	public CommunityResponse updateCommunity(Long userId,Long communityId, CommunityUpdateRequest communityUpdateRequest) {
+	public CommunityResponse updateCommunity(Long communityId,Long userId, CommunityUpdateRequest communityUpdateRequest) {
 		Community community = communityRepository.findById(communityId)
 			.orElseThrow(() -> new CommonException(ErrorCode.COMMUNITY_NOT_FOUND));
 

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/CommunityUseCaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/CommunityUseCaseImpl.java
@@ -10,7 +10,10 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommunityCreateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommunityUpdateRequest;
+import tave.crezipsa.crezipsa.application.community.dto.response.CommentResponse;
 import tave.crezipsa.crezipsa.application.community.dto.response.CommunityDetailResponse;
+import tave.crezipsa.crezipsa.application.community.dto.response.CommunityResponse;
+import tave.crezipsa.crezipsa.application.community.dto.response.CommunitySummaryResponse;
 import tave.crezipsa.crezipsa.application.community.dto.response.MyCommunityResponse;
 import tave.crezipsa.crezipsa.domain.community.domain.Community;
 import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
@@ -29,9 +32,10 @@ public class CommunityUseCaseImpl implements CommunityUseCase {
 	private final CommunityRepository communityRepository;
 	private final LikeRepository likeRepository;
 	private final CommentRepository commentRepository;
+	private final CommentUsecase commentUsecase;
 
 	@Override
-	public CommunityDetailResponse createCommunity(Long userId, CommunityCreateRequest communityCreateRequest) {
+	public CommunityResponse createCommunity(Long userId, CommunityCreateRequest communityCreateRequest) {
 		Community community = Community.builder()
 			.title(communityCreateRequest.getTitle())
 			.content(communityCreateRequest.getContent())
@@ -41,11 +45,11 @@ public class CommunityUseCaseImpl implements CommunityUseCase {
 			.likeCount(0L)
 			.build();
 
-		return CommunityDetailResponse.from(communityRepository.save(community));
+		return CommunityResponse.of(communityRepository.save(community));
 	}
 
 	@Override
-	public CommunityDetailResponse updateCommunity(Long userId,Long communityId, CommunityUpdateRequest communityUpdateRequest) {
+	public CommunityResponse updateCommunity(Long userId,Long communityId, CommunityUpdateRequest communityUpdateRequest) {
 		Community community = communityRepository.findById(communityId)
 			.orElseThrow(() -> new CommonException(ErrorCode.COMMUNITY_NOT_FOUND));
 
@@ -53,7 +57,7 @@ public class CommunityUseCaseImpl implements CommunityUseCase {
 			throw new CommonException(ErrorCode.UNAUTHORIZED_COMMUNITY);
 		}
 		community.update(communityUpdateRequest.getTitle(), communityUpdateRequest.getContent(), communityUpdateRequest.getImageUrls());
-		return CommunityDetailResponse.from(community);
+		return CommunityResponse.of(community);
 	}
 
 	@Override
@@ -61,14 +65,22 @@ public class CommunityUseCaseImpl implements CommunityUseCase {
 		Community community = communityRepository.findById(communityId)
 			.orElseThrow(() -> new CommonException(ErrorCode.COMMUNITY_NOT_FOUND));
 
-		return CommunityDetailResponse.from(community);
+		long commentCount = commentRepository.countByCommunityId(communityId);
+		List<CommentResponse> comments = commentUsecase.getComments(communityId);
+
+
+		return CommunityDetailResponse.from(community, commentCount, comments);
 	}
 
 	@Override
-	public List<CommunityDetailResponse> getAllCommunities() {
+	public List<CommunitySummaryResponse> getAllCommunities() {
 		return communityRepository.findAll().stream()
-			.map(CommunityDetailResponse::from)
-			.collect(Collectors.toList());
+			.map(c -> {
+				long likeCount = likeRepository.countByCommunityIdAndIsLikedTrue(c.getCommunityId());
+				long commentCount = commentRepository.countByCommunityId(c.getCommunityId());
+				return CommunitySummaryResponse.of(c, likeCount, commentCount);
+			})
+			.toList();
 	}
 
 	@Override
@@ -95,10 +107,14 @@ public class CommunityUseCaseImpl implements CommunityUseCase {
 	}
 
 	@Override
-	public List<CommunityDetailResponse> getCommunitiesByField(CommunityField field) {
+	public List<CommunitySummaryResponse> getCommunitiesByField(CommunityField field) {
 		return communityRepository.findByField(field)
 			.stream()
-			.map(CommunityDetailResponse::from)
+			.map(c -> {
+				long likeCount = likeRepository.countByCommunityIdAndIsLikedTrue(c.getCommunityId());
+				long commentCount = commentRepository.countByCommunityId(c.getCommunityId());
+				return CommunitySummaryResponse.of(c, likeCount, commentCount);
+			})
 			.toList();
 	}
 

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/CommunityUseCaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/CommunityUseCaseImpl.java
@@ -11,9 +11,12 @@ import lombok.RequiredArgsConstructor;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommunityCreateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommunityUpdateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.response.CommunityResponse;
+import tave.crezipsa.crezipsa.application.community.dto.response.MyCommunityResponse;
 import tave.crezipsa.crezipsa.domain.community.domain.Community;
 import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
+import tave.crezipsa.crezipsa.domain.community.repository.CommentRepository;
 import tave.crezipsa.crezipsa.domain.community.repository.CommunityRepository;
+import tave.crezipsa.crezipsa.domain.community.repository.LikeRepository;
 import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
 import tave.crezipsa.crezipsa.global.exception.model.CommonException;
 
@@ -24,6 +27,8 @@ public class CommunityUseCaseImpl implements CommunityUseCase {
 
 
 	private final CommunityRepository communityRepository;
+	private final LikeRepository likeRepository;
+	private final CommentRepository commentRepository;
 
 	@Override
 	public CommunityResponse createCommunity(Long userId, CommunityCreateRequest communityCreateRequest) {
@@ -78,10 +83,14 @@ public class CommunityUseCaseImpl implements CommunityUseCase {
 	}
 
 	@Override
-	public List<CommunityResponse> getMyCommunities(Long userId) {
+	public List<MyCommunityResponse> getMyCommunities(Long userId) {
 		return communityRepository.findByWriterId(userId)
 			.stream()
-			.map(CommunityResponse::from)
+			.map(c -> {
+				long likeCount = likeRepository.countByCommunityIdAndIsLikedTrue(c.getCommunityId());
+				long commentCount = commentRepository.countByCommunityId(c.getCommunityId());
+				return MyCommunityResponse.of(c, likeCount, commentCount);
+			})
 			.toList();
 	}
 

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/CommunityUseCaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/CommunityUseCaseImpl.java
@@ -10,7 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommunityCreateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommunityUpdateRequest;
-import tave.crezipsa.crezipsa.application.community.dto.response.CommunityResponse;
+import tave.crezipsa.crezipsa.application.community.dto.response.CommunityDetailResponse;
 import tave.crezipsa.crezipsa.application.community.dto.response.MyCommunityResponse;
 import tave.crezipsa.crezipsa.domain.community.domain.Community;
 import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
@@ -31,7 +31,7 @@ public class CommunityUseCaseImpl implements CommunityUseCase {
 	private final CommentRepository commentRepository;
 
 	@Override
-	public CommunityResponse createCommunity(Long userId, CommunityCreateRequest communityCreateRequest) {
+	public CommunityDetailResponse createCommunity(Long userId, CommunityCreateRequest communityCreateRequest) {
 		Community community = Community.builder()
 			.title(communityCreateRequest.getTitle())
 			.content(communityCreateRequest.getContent())
@@ -41,11 +41,11 @@ public class CommunityUseCaseImpl implements CommunityUseCase {
 			.likeCount(0L)
 			.build();
 
-		return CommunityResponse.from(communityRepository.save(community));
+		return CommunityDetailResponse.from(communityRepository.save(community));
 	}
 
 	@Override
-	public CommunityResponse updateCommunity(Long userId,Long communityId, CommunityUpdateRequest communityUpdateRequest) {
+	public CommunityDetailResponse updateCommunity(Long userId,Long communityId, CommunityUpdateRequest communityUpdateRequest) {
 		Community community = communityRepository.findById(communityId)
 			.orElseThrow(() -> new CommonException(ErrorCode.COMMUNITY_NOT_FOUND));
 
@@ -53,21 +53,21 @@ public class CommunityUseCaseImpl implements CommunityUseCase {
 			throw new CommonException(ErrorCode.UNAUTHORIZED_COMMUNITY);
 		}
 		community.update(communityUpdateRequest.getTitle(), communityUpdateRequest.getContent(), communityUpdateRequest.getImageUrls());
-		return CommunityResponse.from(community);
+		return CommunityDetailResponse.from(community);
 	}
 
 	@Override
-	public CommunityResponse getCommunity(Long communityId) {
+	public CommunityDetailResponse getCommunity(Long communityId) {
 		Community community = communityRepository.findById(communityId)
 			.orElseThrow(() -> new CommonException(ErrorCode.COMMUNITY_NOT_FOUND));
 
-		return CommunityResponse.from(community);
+		return CommunityDetailResponse.from(community);
 	}
 
 	@Override
-	public List<CommunityResponse> getAllCommunities() {
+	public List<CommunityDetailResponse> getAllCommunities() {
 		return communityRepository.findAll().stream()
-			.map(CommunityResponse::from)
+			.map(CommunityDetailResponse::from)
 			.collect(Collectors.toList());
 	}
 
@@ -95,10 +95,10 @@ public class CommunityUseCaseImpl implements CommunityUseCase {
 	}
 
 	@Override
-	public List<CommunityResponse> getCommunitiesByField(CommunityField field) {
+	public List<CommunityDetailResponse> getCommunitiesByField(CommunityField field) {
 		return communityRepository.findByField(field)
 			.stream()
-			.map(CommunityResponse::from)
+			.map(CommunityDetailResponse::from)
 			.toList();
 	}
 

--- a/src/main/java/tave/crezipsa/crezipsa/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/tave/crezipsa/crezipsa/global/security/JwtAuthenticationFilter.java
@@ -6,6 +6,9 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import tave.crezipsa.crezipsa.domain.user.entity.User;
+import tave.crezipsa.crezipsa.domain.user.repository.UserRepository;
+
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -19,32 +22,45 @@ import java.util.Collections;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
 
     @Override
     public void doFilterInternal(HttpServletRequest request,
-                                HttpServletResponse response,
-                                FilterChain filterChain)
-            throws ServletException, IOException {
+        HttpServletResponse response,
+        FilterChain filterChain)
+        throws ServletException, IOException {
+
         String token = resolveToken(request);
 
         if (token != null) {
             String userId = jwtTokenProvider.getUserIdFromToken(token);
 
-            UsernamePasswordAuthenticationToken authentication =
-                    new UsernamePasswordAuthenticationToken(userId, null, Collections.emptyList());
+            // DB에서 User 엔티티 조회
+            User user = userRepository.findById(Long.valueOf(userId))
+                .orElse(null);
 
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+            if (user != null) {
+                UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                        user,      // ★ Principal로 User 넣기
+                        null,
+                        Collections.emptyList()
+                    );
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
         }
 
         filterChain.doFilter(request, response);
     }
 
-    private String resolveToken(HttpServletRequest request) {
-        String bearer = request.getHeader("Authorization");
-        if (bearer != null && bearer.startsWith("Bearer ")) {
-            return bearer.substring(7);
-        }
-        return null;
-    }
 
+    private String resolveToken (HttpServletRequest request){
+            String bearer = request.getHeader("Authorization");
+            if (bearer != null && bearer.startsWith("Bearer ")) {
+                return bearer.substring(7);
+            }
+            return null;
+        }
+        
 }

--- a/src/main/java/tave/crezipsa/crezipsa/global/security/JwtTokenProvider.java
+++ b/src/main/java/tave/crezipsa/crezipsa/global/security/JwtTokenProvider.java
@@ -64,7 +64,7 @@ public class JwtTokenProvider {
     public String getUserIdFromToken(String token) {
         return Jwts.parser()
                 .setSigningKey(secretKey)
-                .parseClaimsJwt(token)
+                .parseClaimsJws(token) // 수정
                 .getBody()
                 .getSubject();
     }

--- a/src/main/java/tave/crezipsa/crezipsa/presentation/community/controller/CommentController.java
+++ b/src/main/java/tave/crezipsa/crezipsa/presentation/community/controller/CommentController.java
@@ -18,6 +18,7 @@ import tave.crezipsa.crezipsa.application.community.dto.request.CommentCreateReq
 import tave.crezipsa.crezipsa.application.community.dto.request.CommentUpdateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.response.CommentResponse;
 import tave.crezipsa.crezipsa.application.community.dto.response.CommunityResponse;
+import tave.crezipsa.crezipsa.application.community.dto.response.MyCommentResponse;
 import tave.crezipsa.crezipsa.application.community.usecase.CommentUsecase;
 import tave.crezipsa.crezipsa.global.common.dto.GlobalResponseDto;
 
@@ -69,8 +70,8 @@ public class CommentController {
 
 	// 5) 내가 쓴 댓글 조회(내 댓글함)
 	@GetMapping("/my")
-	public GlobalResponseDto<List<CommentResponse>> getMyComments(@RequestParam Long userId) {
-		List<CommentResponse> responses = commentUsecase.getMyComments(userId);
+	public GlobalResponseDto<List<MyCommentResponse>> getMyComments(@RequestParam Long userId) {
+		List<MyCommentResponse> responses = commentUsecase.getMyComments(userId);
 		return GlobalResponseDto.success(responses);
 	}
 

--- a/src/main/java/tave/crezipsa/crezipsa/presentation/community/controller/CommentController.java
+++ b/src/main/java/tave/crezipsa/crezipsa/presentation/community/controller/CommentController.java
@@ -2,6 +2,7 @@ package tave.crezipsa.crezipsa.presentation.community.controller;
 
 import java.util.List;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -17,9 +18,9 @@ import lombok.RequiredArgsConstructor;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommentCreateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommentUpdateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.response.CommentResponse;
-import tave.crezipsa.crezipsa.application.community.dto.response.CommunityResponse;
 import tave.crezipsa.crezipsa.application.community.dto.response.MyCommentResponse;
 import tave.crezipsa.crezipsa.application.community.usecase.CommentUsecase;
+import tave.crezipsa.crezipsa.domain.user.entity.User;
 import tave.crezipsa.crezipsa.global.common.dto.GlobalResponseDto;
 
 @RestController
@@ -32,32 +33,32 @@ public class CommentController {
 	//댓글 달기
 	@PostMapping("/{communityId}")
 	public GlobalResponseDto<CommentResponse> createComment(
+		@AuthenticationPrincipal User user,
 		@PathVariable Long communityId,
-		@RequestParam Long userId,           // 임시로 userId 받기 + 나중에 UserContext에서 가져오기
 		@Valid @RequestBody CommentCreateRequest request
 	) {
-		CommentResponse response = commentUsecase.createComment(communityId, userId, request);
+		CommentResponse response = commentUsecase.createComment(communityId, user.getUserId(), request);
 		return GlobalResponseDto.success(response);
 	}
 
 	// 2) 댓글 수정
 	@PatchMapping("/{commentId}")
 	public GlobalResponseDto<CommentResponse> updateComment(
+		@AuthenticationPrincipal User user,
 		@PathVariable Long commentId,
-		@RequestParam Long userId,
 		@Valid @RequestBody CommentUpdateRequest request
 	) {
-		CommentResponse response = commentUsecase.updateComment(commentId, userId, request);
+		CommentResponse response = commentUsecase.updateComment(commentId, user.getUserId(), request);
 		return GlobalResponseDto.success(response);
 	}
 
 	// 3) 댓글 삭제
 	@DeleteMapping("/{commentId}")
 	public GlobalResponseDto<Void> deleteComment(
-		@PathVariable Long commentId,
-		@RequestParam Long userId
+		@AuthenticationPrincipal User user,
+		@PathVariable Long commentId
 	) {
-		commentUsecase.deleteComment(commentId, userId);
+		commentUsecase.deleteComment(commentId, user.getUserId());
 		return GlobalResponseDto.success();
 	}
 
@@ -70,8 +71,8 @@ public class CommentController {
 
 	// 5) 내가 쓴 댓글 조회(내 댓글함)
 	@GetMapping("/my")
-	public GlobalResponseDto<List<MyCommentResponse>> getMyComments(@RequestParam Long userId) {
-		List<MyCommentResponse> responses = commentUsecase.getMyComments(userId);
+	public GlobalResponseDto<List<MyCommentResponse>> getMyComments(@AuthenticationPrincipal User user) {
+		List<MyCommentResponse> responses = commentUsecase.getMyComments(user.getUserId());
 		return GlobalResponseDto.success(responses);
 	}
 

--- a/src/main/java/tave/crezipsa/crezipsa/presentation/community/controller/CommunityController.java
+++ b/src/main/java/tave/crezipsa/crezipsa/presentation/community/controller/CommunityController.java
@@ -2,6 +2,7 @@ package tave.crezipsa.crezipsa.presentation.community.controller;
 
 import java.util.List;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,6 +22,7 @@ import tave.crezipsa.crezipsa.application.community.dto.response.CommunityRespon
 import tave.crezipsa.crezipsa.application.community.dto.response.MyCommunityResponse;
 import tave.crezipsa.crezipsa.application.community.usecase.CommunityUseCase;
 import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
+import tave.crezipsa.crezipsa.domain.user.entity.User;
 import tave.crezipsa.crezipsa.global.common.dto.GlobalResponseDto;
 
 @RestController
@@ -34,10 +36,10 @@ public class CommunityController {
 	//글 생성
 	@PostMapping("/create")
 	public GlobalResponseDto<CommunityResponse> createCommunity(
-		@RequestParam Long userId,
-		@Valid @RequestBody CommunityCreateRequest request) {
-
-		CommunityResponse response = communityUseCase.createCommunity(userId, request);
+		@AuthenticationPrincipal User user,
+		@Valid @RequestBody CommunityCreateRequest request)
+	{
+		CommunityResponse response = communityUseCase.createCommunity(user.getUserId(), request);
 		return GlobalResponseDto.success(response);
 	}
 
@@ -45,10 +47,10 @@ public class CommunityController {
 	@PatchMapping("/{communityId}")
 	public GlobalResponseDto<CommunityResponse> updateCommunity(
 		@PathVariable Long communityId,
-		@RequestParam Long userId,
+		@AuthenticationPrincipal User user,
 		@Valid @RequestBody CommunityUpdateRequest request
 	) {
-		CommunityResponse response = communityUseCase.updateCommunity(communityId, userId, request);
+		CommunityResponse response = communityUseCase.updateCommunity(communityId, user.getUserId(), request);
 		return GlobalResponseDto.success(response);
 	}
 
@@ -77,16 +79,16 @@ public class CommunityController {
 	//내가 쓴 글 조회
 	@GetMapping("/users/{userId}")
 	public GlobalResponseDto<List<MyCommunityResponse>> getCommunitiesByUserId(
-		@PathVariable Long userId) {
+		@AuthenticationPrincipal User user) {
 
-		List<MyCommunityResponse> responses = communityUseCase.getMyCommunities(userId);
+		List<MyCommunityResponse> responses = communityUseCase.getMyCommunities(user.getUserId());
 		return GlobalResponseDto.success(responses);
 	}
 
 	//글 삭제
 	@DeleteMapping("/{communityId}")
-	public GlobalResponseDto<Void> deleteCommunity( @RequestParam Long userId,@PathVariable Long communityId) {
-		communityUseCase.deleteCommunity(userId, communityId);
+	public GlobalResponseDto<Void> deleteCommunity( @AuthenticationPrincipal User user,@PathVariable Long communityId) {
+		communityUseCase.deleteCommunity(user.getUserId(), communityId);
 		return GlobalResponseDto.success();
 	}
 

--- a/src/main/java/tave/crezipsa/crezipsa/presentation/community/controller/CommunityController.java
+++ b/src/main/java/tave/crezipsa/crezipsa/presentation/community/controller/CommunityController.java
@@ -18,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommunityCreateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommunityUpdateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.response.CommunityResponse;
+import tave.crezipsa.crezipsa.application.community.dto.response.MyCommunityResponse;
 import tave.crezipsa.crezipsa.application.community.usecase.CommunityUseCase;
 import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
 import tave.crezipsa.crezipsa.global.common.dto.GlobalResponseDto;
@@ -75,10 +76,10 @@ public class CommunityController {
 
 	//내가 쓴 글 조회
 	@GetMapping("/users/{userId}")
-	public GlobalResponseDto<List<CommunityResponse>> getCommunitiesByUserId(
+	public GlobalResponseDto<List<MyCommunityResponse>> getCommunitiesByUserId(
 		@PathVariable Long userId) {
 
-		List<CommunityResponse> responses = communityUseCase.getMyCommunities(userId);
+		List<MyCommunityResponse> responses = communityUseCase.getMyCommunities(userId);
 		return GlobalResponseDto.success(responses);
 	}
 

--- a/src/main/java/tave/crezipsa/crezipsa/presentation/community/controller/CommunityController.java
+++ b/src/main/java/tave/crezipsa/crezipsa/presentation/community/controller/CommunityController.java
@@ -79,7 +79,7 @@ public class CommunityController {
 	}
 
 	//내가 쓴 글 조회
-	@GetMapping("/users/{userId}")
+	@GetMapping("/my")
 	public GlobalResponseDto<List<MyCommunityResponse>> getCommunitiesByUserId(
 		@AuthenticationPrincipal User user) {
 

--- a/src/main/java/tave/crezipsa/crezipsa/presentation/community/controller/CommunityController.java
+++ b/src/main/java/tave/crezipsa/crezipsa/presentation/community/controller/CommunityController.java
@@ -18,7 +18,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommunityCreateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommunityUpdateRequest;
-import tave.crezipsa.crezipsa.application.community.dto.response.CommunityResponse;
+import tave.crezipsa.crezipsa.application.community.dto.response.CommunityDetailResponse;
 import tave.crezipsa.crezipsa.application.community.dto.response.MyCommunityResponse;
 import tave.crezipsa.crezipsa.application.community.usecase.CommunityUseCase;
 import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
@@ -35,44 +35,44 @@ public class CommunityController {
 
 	//글 생성
 	@PostMapping("/create")
-	public GlobalResponseDto<CommunityResponse> createCommunity(
+	public GlobalResponseDto<CommunityDetailResponse> createCommunity(
 		@AuthenticationPrincipal User user,
 		@Valid @RequestBody CommunityCreateRequest request)
 	{
-		CommunityResponse response = communityUseCase.createCommunity(user.getUserId(), request);
+		CommunityDetailResponse response = communityUseCase.createCommunity(user.getUserId(), request);
 		return GlobalResponseDto.success(response);
 	}
 
 	// 글 수정
 	@PatchMapping("/{communityId}")
-	public GlobalResponseDto<CommunityResponse> updateCommunity(
+	public GlobalResponseDto<CommunityDetailResponse> updateCommunity(
 		@PathVariable Long communityId,
 		@AuthenticationPrincipal User user,
 		@Valid @RequestBody CommunityUpdateRequest request
 	) {
-		CommunityResponse response = communityUseCase.updateCommunity(communityId, user.getUserId(), request);
+		CommunityDetailResponse response = communityUseCase.updateCommunity(communityId, user.getUserId(), request);
 		return GlobalResponseDto.success(response);
 	}
 
 	//상세 글 조회
 	@GetMapping("/{communityId}")
-	public GlobalResponseDto<CommunityResponse> getCommunity(@PathVariable Long communityId) {
+	public GlobalResponseDto<CommunityDetailResponse> getCommunity(@PathVariable Long communityId) {
 		return GlobalResponseDto.success(communityUseCase.getCommunity(communityId));
 	}
 
 	//전체 글 조회
 	@GetMapping
-	public GlobalResponseDto<List<CommunityResponse>> getAllCommunities() {
-		List<CommunityResponse> communityResponses = communityUseCase.getAllCommunities();
+	public GlobalResponseDto<List<CommunityDetailResponse>> getAllCommunities() {
+		List<CommunityDetailResponse> communityResponses = communityUseCase.getAllCommunities();
 		return GlobalResponseDto.success(communityResponses);
 	}
 
 	//카테고리별 글 조회
 	@GetMapping("/filter")
-	public GlobalResponseDto<List<CommunityResponse>> getCommunitiesByField(
+	public GlobalResponseDto<List<CommunityDetailResponse>> getCommunitiesByField(
 		@RequestParam CommunityField field) {
 
-		List<CommunityResponse> responses = communityUseCase.getCommunitiesByField(field);
+		List<CommunityDetailResponse> responses = communityUseCase.getCommunitiesByField(field);
 		return GlobalResponseDto.success(responses);
 	}
 

--- a/src/main/java/tave/crezipsa/crezipsa/presentation/community/controller/CommunityController.java
+++ b/src/main/java/tave/crezipsa/crezipsa/presentation/community/controller/CommunityController.java
@@ -19,6 +19,8 @@ import lombok.RequiredArgsConstructor;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommunityCreateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommunityUpdateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.response.CommunityDetailResponse;
+import tave.crezipsa.crezipsa.application.community.dto.response.CommunityResponse;
+import tave.crezipsa.crezipsa.application.community.dto.response.CommunitySummaryResponse;
 import tave.crezipsa.crezipsa.application.community.dto.response.MyCommunityResponse;
 import tave.crezipsa.crezipsa.application.community.usecase.CommunityUseCase;
 import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
@@ -35,22 +37,22 @@ public class CommunityController {
 
 	//글 생성
 	@PostMapping("/create")
-	public GlobalResponseDto<CommunityDetailResponse> createCommunity(
+	public GlobalResponseDto<CommunityResponse> createCommunity(
 		@AuthenticationPrincipal User user,
 		@Valid @RequestBody CommunityCreateRequest request)
 	{
-		CommunityDetailResponse response = communityUseCase.createCommunity(user.getUserId(), request);
+		CommunityResponse response = communityUseCase.createCommunity(user.getUserId(), request);
 		return GlobalResponseDto.success(response);
 	}
 
 	// 글 수정
 	@PatchMapping("/{communityId}")
-	public GlobalResponseDto<CommunityDetailResponse> updateCommunity(
+	public GlobalResponseDto<CommunityResponse> updateCommunity(
 		@PathVariable Long communityId,
 		@AuthenticationPrincipal User user,
 		@Valid @RequestBody CommunityUpdateRequest request
 	) {
-		CommunityDetailResponse response = communityUseCase.updateCommunity(communityId, user.getUserId(), request);
+		CommunityResponse response = communityUseCase.updateCommunity(communityId, user.getUserId(), request);
 		return GlobalResponseDto.success(response);
 	}
 
@@ -62,17 +64,17 @@ public class CommunityController {
 
 	//전체 글 조회
 	@GetMapping
-	public GlobalResponseDto<List<CommunityDetailResponse>> getAllCommunities() {
-		List<CommunityDetailResponse> communityResponses = communityUseCase.getAllCommunities();
+	public GlobalResponseDto<List<CommunitySummaryResponse>> getAllCommunities() {
+		List<CommunitySummaryResponse> communityResponses = communityUseCase.getAllCommunities();
 		return GlobalResponseDto.success(communityResponses);
 	}
 
 	//카테고리별 글 조회
 	@GetMapping("/filter")
-	public GlobalResponseDto<List<CommunityDetailResponse>> getCommunitiesByField(
+	public GlobalResponseDto<List<CommunitySummaryResponse>> getCommunitiesByField(
 		@RequestParam CommunityField field) {
 
-		List<CommunityDetailResponse> responses = communityUseCase.getCommunitiesByField(field);
+		List<CommunitySummaryResponse> responses = communityUseCase.getCommunitiesByField(field);
 		return GlobalResponseDto.success(responses);
 	}
 

--- a/src/main/java/tave/crezipsa/crezipsa/presentation/community/controller/LikeController.java
+++ b/src/main/java/tave/crezipsa/crezipsa/presentation/community/controller/LikeController.java
@@ -24,7 +24,7 @@ import tave.crezipsa.crezipsa.global.common.dto.GlobalResponseDto;
 public class LikeController {
 
 	private final LikeUseCase likeUseCase;
-/*
+
 	@PostMapping("/{communityId}")
 	public GlobalResponseDto<Void> like(@AuthenticationPrincipal User user, @PathVariable Long communityId) {
 		likeUseCase.like(user.getUserId(), communityId);
@@ -50,7 +50,8 @@ public class LikeController {
 		var slice = likeUseCase.getMyLikedCommunities(user.getUserId(), pageable);
 		return GlobalResponseDto.success(slice.getContent());
 	}
-*/
+
+	/*
     @PostMapping("/{communityId}")
 	public GlobalResponseDto<Void> like(@RequestParam Long userId, @PathVariable Long communityId) {
 		likeUseCase.like(userId, communityId);
@@ -76,5 +77,7 @@ public class LikeController {
 		var slice = likeUseCase.getMyLikedCommunities(userId, pageable);
 		return GlobalResponseDto.success(slice.getContent());
 	}
+
+	 */
 
 }

--- a/src/main/java/tave/crezipsa/crezipsa/presentation/community/controller/LikeController.java
+++ b/src/main/java/tave/crezipsa/crezipsa/presentation/community/controller/LikeController.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->

### 변경사항 1 . 컨트롤러 매개변수 ( Long UserId -> User user) 
인증인가 및 회원가입 로직이 구현됨에 따라 임의로 userId를 넣어주던 방식에서 
ContextHolder에서 인증객체를 가져와 get하는 방식으로 변경 및 테스트


### 변경사항 2. 커뮤니티 반환 DTO 역할 별 분리
피그마UI 및 요구사항에 맞게끔 각각 조회에 따라 반환되는 필드에 따라 DTO를 분리 및 반환타입 맞추기


### 변경사항 3.  실제 테스트를 위해 회원가입 부터 토큰발급을 통틀어 모든 API 테스트
토큰 파싱 방식 
JwtTokenProvider 파일에서 parseClaimsJwt -> parseClaimsJws로 변경 

JwtAuthenticationFilter 에서 ContextHolder에서 저장 대상 userId-> User로 변경

## 🔍 참고 사항
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->


## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
곧 테스트 스크린샷 추가해놓겠습니다~~
## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인