### PR TITLE
Feat/#19/마이페이지개발

### DIFF
--- a/src/main/java/tave/crezipsa/crezipsa/application/auth/service/KakaoLoginService.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/auth/service/KakaoLoginService.java
@@ -24,8 +24,8 @@ public class KakaoLoginService {
 
     public LoginResponse login(String code) {
 
-        String accessToken = kakaoOAuthClient.getAccessToken(code);
-        KakaoUserInfo kakaoUserInfo = kakaoOAuthClient.getUserInfo(accessToken);
+        String kakaoToken = kakaoOAuthClient.getAccessToken(code);
+        KakaoUserInfo kakaoUserInfo = kakaoOAuthClient.getUserInfo(kakaoToken);
 
         User user = userRepository.findByEmail(kakaoUserInfo.getEmail())
                 .orElse(null);
@@ -48,7 +48,7 @@ public class KakaoLoginService {
                         .build()
                 );
 
-        auth.updateTokens(accessToken, refreshToken);
+        auth.updateTokens(kakaoToken, refreshToken);
         authRepository.save(auth);
 
         return LoginResponse.success(jwt, refreshToken, kakaoUserInfo);

--- a/src/main/java/tave/crezipsa/crezipsa/application/user/dto/request/UserInterestRequest.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/user/dto/request/UserInterestRequest.java
@@ -1,6 +1,7 @@
 package tave.crezipsa.crezipsa.application.user.dto.request;
 
 public record UserInterestRequest(
+        Long interestId,
         String category
 ) {
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/user/dto/request/UserInterestRequest.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/user/dto/request/UserInterestRequest.java
@@ -1,0 +1,6 @@
+package tave.crezipsa.crezipsa.application.user.dto.request;
+
+public record UserInterestRequest(
+        String category
+) {
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/user/dto/response/UserInterestResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/user/dto/response/UserInterestResponse.java
@@ -1,8 +1,17 @@
 package tave.crezipsa.crezipsa.application.user.dto.response;
 
+import tave.crezipsa.crezipsa.domain.user.entity.UserInterest;
+
 public record UserInterestResponse(
         Long userId,
         Long interestId,
         String category
 ) {
+    public static UserInterestResponse from(UserInterest userInterest) {
+        return new UserInterestResponse(
+                userInterest.getUserId(),
+                userInterest.getInterestId(),
+                userInterest.getCategory()
+        );
+    }
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/user/dto/response/UserInterestResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/user/dto/response/UserInterestResponse.java
@@ -2,6 +2,7 @@ package tave.crezipsa.crezipsa.application.user.dto.response;
 
 public record UserInterestResponse(
         Long userId,
+        Long interestId,
         String category
 ) {
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/user/dto/response/UserInterestResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/user/dto/response/UserInterestResponse.java
@@ -1,0 +1,7 @@
+package tave.crezipsa.crezipsa.application.user.dto.response;
+
+public record UserInterestResponse(
+        Long userId,
+        String category
+) {
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/user/dto/response/UserSignUpResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/user/dto/response/UserSignUpResponse.java
@@ -1,7 +1,16 @@
 package tave.crezipsa.crezipsa.application.user.dto.response;
 
+import tave.crezipsa.crezipsa.domain.user.entity.User;
+
 public record UserSignUpResponse (
     String nickName,
     String email
+
 ){
+    public static UserSignUpResponse from(User user) {
+        return new UserSignUpResponse(
+                user.getNickName(),
+                user.getEmail()
+        );
+    }
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/user/dto/response/UserUpdateResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/user/dto/response/UserUpdateResponse.java
@@ -1,11 +1,9 @@
-package tave.crezipsa.crezipsa.application.user.dto.request;
+package tave.crezipsa.crezipsa.application.user.dto.response;
 
-import tave.crezipsa.crezipsa.domain.user.enums.Gender;
 import tave.crezipsa.crezipsa.domain.user.enums.Platform;
 
-import java.time.LocalDate;
-
-public record UserUpdateRequest(
+public record UserUpdateResponse(
+        Long userId,
         String activeYoutube,
         String activeTiktok,
         String activeInsta,

--- a/src/main/java/tave/crezipsa/crezipsa/application/user/dto/response/UserUpdateResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/user/dto/response/UserUpdateResponse.java
@@ -1,5 +1,6 @@
 package tave.crezipsa.crezipsa.application.user.dto.response;
 
+import tave.crezipsa.crezipsa.domain.user.entity.User;
 import tave.crezipsa.crezipsa.domain.user.enums.Platform;
 
 public record UserUpdateResponse(
@@ -8,5 +9,15 @@ public record UserUpdateResponse(
         String activeTiktok,
         String activeInsta,
         Platform mainPlatform
+
 ) {
+    public static UserUpdateResponse from(User user) {
+        return new UserUpdateResponse(
+                user.getUserId(),
+                user.getActiveYoutube(),
+                user.getActiveTiktok(),
+                user.getActiveInsta(),
+                user.getMainPlatform()
+        );
+    }
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/user/usecase/UserUsecase.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/user/usecase/UserUsecase.java
@@ -1,7 +1,9 @@
 package tave.crezipsa.crezipsa.application.user.usecase;
 
+import tave.crezipsa.crezipsa.application.user.dto.request.UserInterestRequest;
 import tave.crezipsa.crezipsa.application.user.dto.request.UserSignUpRequest;
 import tave.crezipsa.crezipsa.application.user.dto.request.UserUpdateRequest;
+import tave.crezipsa.crezipsa.application.user.dto.response.UserInterestResponse;
 import tave.crezipsa.crezipsa.application.user.dto.response.UserSignUpResponse;
 import tave.crezipsa.crezipsa.application.user.dto.response.UserUpdateResponse;
 import tave.crezipsa.crezipsa.global.common.dto.GlobalResponseDto;
@@ -10,4 +12,5 @@ import tave.crezipsa.crezipsa.global.common.dto.GlobalResponseDto;
 public interface UserUsecase {
     UserSignUpResponse signUp(UserSignUpRequest userSignUpRequest);
     UserUpdateResponse update(Long userId, UserUpdateRequest request);
+    UserInterestResponse addUserInsert(Long userId, UserInterestRequest request);
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/user/usecase/UserUsecase.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/user/usecase/UserUsecase.java
@@ -3,10 +3,11 @@ package tave.crezipsa.crezipsa.application.user.usecase;
 import tave.crezipsa.crezipsa.application.user.dto.request.UserSignUpRequest;
 import tave.crezipsa.crezipsa.application.user.dto.request.UserUpdateRequest;
 import tave.crezipsa.crezipsa.application.user.dto.response.UserSignUpResponse;
+import tave.crezipsa.crezipsa.application.user.dto.response.UserUpdateResponse;
 import tave.crezipsa.crezipsa.global.common.dto.GlobalResponseDto;
 
 
 public interface UserUsecase {
     UserSignUpResponse signUp(UserSignUpRequest userSignUpRequest);
-    GlobalResponseDto update(UserUpdateRequest request);
+    UserUpdateResponse update(Long userId, UserUpdateRequest request);
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/user/usecase/UserUsecase.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/user/usecase/UserUsecase.java
@@ -17,5 +17,5 @@ public interface UserUsecase {
 
     UserInterestResponse addUserInterest(Long userId, UserInterestRequest request);
     List<UserInterestResponse> getUserInterest(Long userId);
-    void deleteUserInterest(Long userId, UserInterestRequest request);
+    void deleteUserInterest(UserInterestRequest request);
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/user/usecase/UserUsecase.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/user/usecase/UserUsecase.java
@@ -8,9 +8,14 @@ import tave.crezipsa.crezipsa.application.user.dto.response.UserSignUpResponse;
 import tave.crezipsa.crezipsa.application.user.dto.response.UserUpdateResponse;
 import tave.crezipsa.crezipsa.global.common.dto.GlobalResponseDto;
 
+import java.util.List;
+
 
 public interface UserUsecase {
     UserSignUpResponse signUp(UserSignUpRequest userSignUpRequest);
     UserUpdateResponse update(Long userId, UserUpdateRequest request);
-    UserInterestResponse addUserInsert(Long userId, UserInterestRequest request);
+
+    UserInterestResponse addUserInterest(Long userId, UserInterestRequest request);
+    List<UserInterestResponse> getUserInterest(Long userId);
+    void deleteUserInterest(Long userId, UserInterestRequest request);
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/user/usecase/UserUsecaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/user/usecase/UserUsecaseImpl.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import tave.crezipsa.crezipsa.application.user.dto.request.UserSignUpRequest;
 import tave.crezipsa.crezipsa.application.user.dto.request.UserUpdateRequest;
 import tave.crezipsa.crezipsa.application.user.dto.response.UserSignUpResponse;
+import tave.crezipsa.crezipsa.application.user.dto.response.UserUpdateResponse;
 import tave.crezipsa.crezipsa.domain.user.command.UserSignUpCommand;
 import tave.crezipsa.crezipsa.domain.user.command.UserUpdateCommand;
 import tave.crezipsa.crezipsa.domain.user.entity.User;
@@ -45,22 +46,30 @@ public class UserUsecaseImpl implements UserUsecase {
 
         User user = User.createFromUser(command);
         User newUser = userRepository.save(user);
+
         return new UserSignUpResponse(newUser.getNickName(), newUser.getEmail());
     }
 
     @Override
-    public GlobalResponseDto update(UserUpdateRequest request) {
+    public UserUpdateResponse update(Long userId, UserUpdateRequest request) {
 
-        User updateUser =  userRepository.findById(request.userId()).
+        User user =  userRepository.findById(userId).
                 orElseThrow(() -> new CommonException(ErrorCode.USER_INVALID_ID));
 
         UserUpdateCommand command = new UserUpdateCommand(
+                request.activeYoutube(),
+                request.activeTiktok(),
                 request.activeInsta(),
-                request.activeYoutube(),
-                request.activeYoutube(),
                 request.mainPlatform()
         );
-        updateUser.updateFromUser(command);
-        return GlobalResponseDto.success("업데이트 완료");
+        user.updateFromUser(command);
+        User updateUser = userRepository.save(user);
+
+        return new UserUpdateResponse(
+                updateUser.getUserId(),
+                updateUser.getActiveYoutube(),
+                updateUser.getActiveTiktok(),
+                updateUser.getActiveInsta(),
+                updateUser.getMainPlatform());
     }
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/user/usecase/UserUsecaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/user/usecase/UserUsecaseImpl.java
@@ -3,17 +3,24 @@ package tave.crezipsa.crezipsa.application.user.usecase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import tave.crezipsa.crezipsa.application.user.dto.request.UserInterestRequest;
 import tave.crezipsa.crezipsa.application.user.dto.request.UserSignUpRequest;
 import tave.crezipsa.crezipsa.application.user.dto.request.UserUpdateRequest;
+import tave.crezipsa.crezipsa.application.user.dto.response.UserInterestResponse;
 import tave.crezipsa.crezipsa.application.user.dto.response.UserSignUpResponse;
 import tave.crezipsa.crezipsa.application.user.dto.response.UserUpdateResponse;
 import tave.crezipsa.crezipsa.domain.user.command.UserSignUpCommand;
 import tave.crezipsa.crezipsa.domain.user.command.UserUpdateCommand;
 import tave.crezipsa.crezipsa.domain.user.entity.User;
+import tave.crezipsa.crezipsa.domain.user.entity.UserInterest;
+import tave.crezipsa.crezipsa.domain.user.repository.UserInterestRepository;
 import tave.crezipsa.crezipsa.domain.user.repository.UserRepository;
 import tave.crezipsa.crezipsa.global.common.dto.GlobalResponseDto;
 import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
 import tave.crezipsa.crezipsa.global.exception.model.CommonException;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +28,7 @@ import tave.crezipsa.crezipsa.global.exception.model.CommonException;
 public class UserUsecaseImpl implements UserUsecase {
 
     private final UserRepository userRepository;
+    private final UserInterestRepository userInterestRepository;
 
     @Override
     public UserSignUpResponse signUp(UserSignUpRequest request) {
@@ -72,4 +80,46 @@ public class UserUsecaseImpl implements UserUsecase {
                 updateUser.getActiveInsta(),
                 updateUser.getMainPlatform());
     }
+
+    @Override
+    public UserInterestResponse addUserInterest(Long userId, UserInterestRequest request) {
+
+        if (userInterestRepository.existsByUserIdAndCategory(userId, request.category())) {
+            throw new CommonException(ErrorCode.ALREADY_INTEREST);
+        }
+
+        UserInterest userInterest = new UserInterest(userId, request.category());
+        UserInterest newUserInterest = userInterestRepository.save(userInterest);
+
+        return new UserInterestResponse(
+                newUserInterest.getUserId(),
+                newUserInterest.getInterestId(),
+                newUserInterest.getCategory());
+    }
+
+    @Override
+    public List<UserInterestResponse> getUserInterest(Long userId) {
+
+        List<UserInterest> interests = userInterestRepository.findAllByUserId(userId);
+        List<UserInterestResponse> responses = new ArrayList<>();
+
+        for (UserInterest interest : interests) {
+            responses.add(new UserInterestResponse(
+                    interest.getUserId(),
+                    interest.getInterestId(),
+                    interest.getCategory()
+            ));
+        }
+
+        return responses;
+    }
+
+    @Override
+    public void deleteUserInterest(Long userId, UserInterestRequest request) {
+        UserInterest userInterest = userInterestRepository.findByUserIdAndCategoryId(userId,request.category())
+                .orElseThrow(() -> new CommonException(ErrorCode.INVALD_INTEREST));
+
+        userInterestRepository.deleteByInterestId(userInterest.getInterestId());
+    }
+
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/user/usecase/UserUsecaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/user/usecase/UserUsecaseImpl.java
@@ -64,15 +64,12 @@ public class UserUsecaseImpl implements UserUsecase {
             throw new CommonException(ErrorCode.ALREADY_INTEREST);
         }
 
-        UserInterest userInterest = new UserInterest(userId, request.category());
-        UserInterest newUserInterest = userInterestRepository.save(userInterest);
+        UserInterest newUserInterest = userInterestRepository.save( UserInterest.create(userId, request.category()) );
 
-        return new UserInterestResponse(
-                newUserInterest.getUserId(),
-                newUserInterest.getInterestId(),
-                newUserInterest.getCategory());
+        return UserInterestResponse.from(newUserInterest);
     }
 
+    @Transactional(readOnly = true)
     @Override
     public List<UserInterestResponse> getUserInterest(Long userId) {
 
@@ -80,11 +77,7 @@ public class UserUsecaseImpl implements UserUsecase {
         List<UserInterestResponse> responses = new ArrayList<>();
 
         for (UserInterest interest : interests) {
-            responses.add(new UserInterestResponse(
-                    interest.getUserId(),
-                    interest.getInterestId(),
-                    interest.getCategory()
-            ));
+            responses.add(UserInterestResponse.from(interest));
         }
 
         return responses;

--- a/src/main/java/tave/crezipsa/crezipsa/application/user/usecase/UserUsecaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/user/usecase/UserUsecaseImpl.java
@@ -15,7 +15,6 @@ import tave.crezipsa.crezipsa.domain.user.entity.User;
 import tave.crezipsa.crezipsa.domain.user.entity.UserInterest;
 import tave.crezipsa.crezipsa.domain.user.repository.UserInterestRepository;
 import tave.crezipsa.crezipsa.domain.user.repository.UserRepository;
-import tave.crezipsa.crezipsa.global.common.dto.GlobalResponseDto;
 import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
 import tave.crezipsa.crezipsa.global.exception.model.CommonException;
 
@@ -84,11 +83,12 @@ public class UserUsecaseImpl implements UserUsecase {
     }
 
     @Override
-    public void deleteUserInterest(Long userId, UserInterestRequest request) {
-        UserInterest userInterest = userInterestRepository.findByUserIdAndCategoryId(userId,request.category())
-                .orElseThrow(() -> new CommonException(ErrorCode.INVALD_INTEREST));
+    public void deleteUserInterest(UserInterestRequest request) {
+        if( !userInterestRepository.existByInterestId(request.interestId()) ){
+            throw new CommonException( ErrorCode.INVALD_INTEREST );
+        }
 
-        userInterestRepository.deleteByInterestId(userInterest.getInterestId());
+        userInterestRepository.deleteByInterestId(request.interestId());
     }
 
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/user/usecase/UserUsecaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/user/usecase/UserUsecaseImpl.java
@@ -40,22 +40,9 @@ public class UserUsecaseImpl implements UserUsecase {
             throw new CommonException(ErrorCode.USER_ALREADY_EXISTS_NICKNAME);
         }
 
-        UserSignUpCommand command = new UserSignUpCommand(
-                request.nickName(),
-                request.email(),
-                request.gender(),
-                false,
-                request.birth(),
-                request.activeYoutube(),
-                request.activeInsta(),
-                request.activeTiktok(),
-                request.mainPlatform()
-        );
+        User user = User.createFromUser(UserSignUpCommand.from(request));
 
-        User user = User.createFromUser(command);
-        User newUser = userRepository.save(user);
-
-        return new UserSignUpResponse(newUser.getNickName(), newUser.getEmail());
+        return UserSignUpResponse.from(userRepository.save(user));
     }
 
     @Override
@@ -64,21 +51,10 @@ public class UserUsecaseImpl implements UserUsecase {
         User user =  userRepository.findById(userId).
                 orElseThrow(() -> new CommonException(ErrorCode.USER_INVALID_ID));
 
-        UserUpdateCommand command = new UserUpdateCommand(
-                request.activeYoutube(),
-                request.activeTiktok(),
-                request.activeInsta(),
-                request.mainPlatform()
-        );
-        user.updateFromUser(command);
-        User updateUser = userRepository.save(user);
+        user.updateFromUser(UserUpdateCommand.from(request));
 
-        return new UserUpdateResponse(
-                updateUser.getUserId(),
-                updateUser.getActiveYoutube(),
-                updateUser.getActiveTiktok(),
-                updateUser.getActiveInsta(),
-                updateUser.getMainPlatform());
+        return UserUpdateResponse.from(userRepository.save(user));
+
     }
 
     @Override

--- a/src/main/java/tave/crezipsa/crezipsa/domain/user/command/UserSignUpCommand.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/user/command/UserSignUpCommand.java
@@ -1,5 +1,6 @@
 package tave.crezipsa.crezipsa.domain.user.command;
 
+import tave.crezipsa.crezipsa.application.user.dto.request.UserSignUpRequest;
 import tave.crezipsa.crezipsa.domain.user.enums.Gender;
 import tave.crezipsa.crezipsa.domain.user.enums.Platform;
 
@@ -16,5 +17,17 @@ public record UserSignUpCommand(
     String activeTiktok,
     Platform mainPlatform
 ) {
-
+    public static UserSignUpCommand from(UserSignUpRequest request){
+        return new UserSignUpCommand(
+                request.nickName(),
+                request.email(),
+                request.gender(),
+                false,
+                request.birth(),
+                request.activeYoutube(),
+                request.activeInsta(),
+                request.activeTiktok(),
+                request.mainPlatform()
+        );
+    }
 }

--- a/src/main/java/tave/crezipsa/crezipsa/domain/user/command/UserUpdateCommand.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/user/command/UserUpdateCommand.java
@@ -4,16 +4,26 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.context.annotation.Configuration;
+import tave.crezipsa.crezipsa.application.user.dto.request.UserUpdateRequest;
 import tave.crezipsa.crezipsa.domain.user.enums.Platform;
 
 @Getter
 @Builder
 @AllArgsConstructor
 public class UserUpdateCommand {
-
     private final String activeInsta;
     private final String activeYoutube;
     private final String activeTiktok;
     private final Platform mainPlatform;
 
+    public static UserUpdateCommand from(UserUpdateRequest request) {
+        return new UserUpdateCommand(
+                request.activeInsta(),
+                request.activeYoutube(),
+                request.activeTiktok(),
+                request.mainPlatform()
+        );
+    }
+
 }
+

--- a/src/main/java/tave/crezipsa/crezipsa/domain/user/entity/User.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/user/entity/User.java
@@ -18,29 +18,34 @@ public class User {
         private String profileImageUrl;
         private boolean role;
         private LocalDate birth;
-        private String activeYotube;
+        private String activeYoutube;
         private String activeTiktok;
         private String activeInsta;
         private Platform mainPlatform;
 
         public static User createFromUser(UserSignUpCommand cmd) {
-            return  User.builder()
+            return User.builder()
                 .nickName(cmd.nickName())
                 .email(cmd.email())
                 .gender(cmd.gender())
                 .role(true)
                 .birth(cmd.birth())
-                .activeYotube(cmd.activeYoutube())
+                .activeYoutube(cmd.activeYoutube())
                 .activeInsta(cmd.activeInsta())
                 .activeTiktok(cmd.activeTiktok())
                 .mainPlatform(cmd.mainPlatform())
                 .build();
         }
         public void updateFromUser(UserUpdateCommand cmd) {
-            if(cmd.getActiveYoutube() != null) { this.activeYotube = cmd.getActiveYoutube(); }
+
+            if(cmd.getActiveYoutube() != null) { this.activeYoutube = cmd.getActiveYoutube(); }
             if(cmd.getActiveInsta() != null) { this.activeInsta = cmd.getActiveInsta() ;}
             if(cmd.getActiveTiktok() != null) { this.activeTiktok = cmd.getActiveTiktok(); }
             if(cmd.getMainPlatform() != null) { this.mainPlatform = cmd.getMainPlatform(); }
+
+            System.out.println(this.mainPlatform);
+            System.out.println("\n\n\n********"+ this.userId );
+
         }
 
 }

--- a/src/main/java/tave/crezipsa/crezipsa/domain/user/entity/User.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/user/entity/User.java
@@ -43,9 +43,6 @@ public class User {
             if(cmd.getActiveTiktok() != null) { this.activeTiktok = cmd.getActiveTiktok(); }
             if(cmd.getMainPlatform() != null) { this.mainPlatform = cmd.getMainPlatform(); }
 
-            System.out.println(this.mainPlatform);
-            System.out.println("\n\n\n********"+ this.userId );
-
         }
 
 }

--- a/src/main/java/tave/crezipsa/crezipsa/domain/user/entity/User.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/user/entity/User.java
@@ -24,6 +24,7 @@ public class User {
         private Platform mainPlatform;
 
         public static User createFromUser(UserSignUpCommand cmd) {
+
             return User.builder()
                 .nickName(cmd.nickName())
                 .email(cmd.email())

--- a/src/main/java/tave/crezipsa/crezipsa/domain/user/entity/UserInterest.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/user/entity/UserInterest.java
@@ -5,9 +5,7 @@ import lombok.*;
 
 @Entity
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Builder
 public class UserInterest {
 
     @Id
@@ -16,5 +14,12 @@ public class UserInterest {
 
     @Column(name = "user_id")
     private Long userId;
+
     private String category;
+
+    public UserInterest(Long userId, String category) {
+        this.userId = userId;
+        this.category = category;
+    }
+
 }

--- a/src/main/java/tave/crezipsa/crezipsa/domain/user/entity/UserInterest.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/user/entity/UserInterest.java
@@ -1,0 +1,20 @@
+package tave.crezipsa.crezipsa.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class UserInterest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long interestId;
+
+    @Column(name = "user_id")
+    private Long userId;
+    private String category;
+}

--- a/src/main/java/tave/crezipsa/crezipsa/domain/user/entity/UserInterest.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/user/entity/UserInterest.java
@@ -17,9 +17,13 @@ public class UserInterest {
 
     private String category;
 
-    public UserInterest(Long userId, String category) {
+    private UserInterest(Long userId, String category) {
         this.userId = userId;
         this.category = category;
+    }
+
+    public static UserInterest create(Long userId, String category) {
+        return new UserInterest(userId, category);
     }
 
 }

--- a/src/main/java/tave/crezipsa/crezipsa/domain/user/enums/Platform.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/user/enums/Platform.java
@@ -2,6 +2,6 @@ package tave.crezipsa.crezipsa.domain.user.enums;
 
 public enum Platform {
     YOUTUBE,
-    INSTAGRAM,
+    INSTA,
     TIKTOK
 }

--- a/src/main/java/tave/crezipsa/crezipsa/domain/user/repository/UserInterestRepository.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/user/repository/UserInterestRepository.java
@@ -3,11 +3,13 @@ package tave.crezipsa.crezipsa.domain.user.repository;
 import tave.crezipsa.crezipsa.domain.user.entity.UserInterest;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface UserInterestRepository {
+
     UserInterest save(UserInterest userInterest);
-
-    UserInterest deleteByUserInterestIdAndUserId(Long interestId, Long userId);
-
+    Boolean deleteByInterestId(Long interestId);
     List<UserInterest> findAllByUserId(Long userId);
+    Boolean existsByUserIdAndCategory(Long userId, String category);
+    Optional<UserInterest> findByUserIdAndCategoryId(Long userId, String category);
 }

--- a/src/main/java/tave/crezipsa/crezipsa/domain/user/repository/UserInterestRepository.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/user/repository/UserInterestRepository.java
@@ -1,0 +1,13 @@
+package tave.crezipsa.crezipsa.domain.user.repository;
+
+import tave.crezipsa.crezipsa.domain.user.entity.UserInterest;
+
+import java.util.List;
+
+public interface UserInterestRepository {
+    UserInterest save(UserInterest userInterest);
+
+    UserInterest deleteByUserInterestIdAndUserId(Long interestId, Long userId);
+
+    List<UserInterest> findAllByUserId(Long userId);
+}

--- a/src/main/java/tave/crezipsa/crezipsa/domain/user/repository/UserInterestRepository.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/user/repository/UserInterestRepository.java
@@ -11,5 +11,5 @@ public interface UserInterestRepository {
     void deleteByInterestId(Long interestId);
     List<UserInterest> findAllByUserId(Long userId);
     Boolean existsByUserIdAndCategory(Long userId, String category);
-    Optional<UserInterest> findByUserIdAndCategoryId(Long userId, String category);
+    Boolean existByInterestId(Long interestId);
 }

--- a/src/main/java/tave/crezipsa/crezipsa/domain/user/repository/UserInterestRepository.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/user/repository/UserInterestRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 public interface UserInterestRepository {
 
     UserInterest save(UserInterest userInterest);
-    Boolean deleteByInterestId(Long interestId);
+    void deleteByInterestId(Long interestId);
     List<UserInterest> findAllByUserId(Long userId);
     Boolean existsByUserIdAndCategory(Long userId, String category);
     Optional<UserInterest> findByUserIdAndCategoryId(Long userId, String category);

--- a/src/main/java/tave/crezipsa/crezipsa/global/exception/code/ErrorCode.java
+++ b/src/main/java/tave/crezipsa/crezipsa/global/exception/code/ErrorCode.java
@@ -5,8 +5,12 @@ public enum ErrorCode implements BaseErrorCode {
 	USER_NOT_FOUND(404, "U40401", "사용자를 찾을 수 없습니다."),
 	USER_ALREADY_EXISTS_EMAIL(404, "U40402", "이미 가입된 이메일입니다."),
 	USER_ALREADY_EXISTS_NICKNAME(404, "U40403", "이미 존재하는 닉네임입니다. "),
-	USER_INVALID_ROLE(401, "U40404","권한이 없는 사용자입니다."),
-	USER_INVALID_ID(401,"U40405", "존재하지 않는 유저입니다."),
+	USER_INVALID_ROLE(401, "U40101","권한이 없는 사용자입니다."),
+	USER_INVALID_ID(401,"U40102", "존재하지 않는 유저입니다."),
+
+
+	INVALD_INTEREST(404,"I40401", "존재하지 않은 사용자 관심 카테고리입니다."),
+	ALREADY_INTEREST(400,"I40001","이미 선택한 사용자 관심 카테고리입니다."),
 
 	// 인증 관련
 	MISSING_AUTH_HEADER(400, "A40101", "Authorization 헤더가 누락되었습니다."),
@@ -24,6 +28,7 @@ public enum ErrorCode implements BaseErrorCode {
 	NOT_LIKED(400,"C40003", "좋아요를 누르지 않은 글입니다."),
 	UNAUTHORIZED_COMMUNITY(404, "C40403", "게시글 권한이 없습니다"),
 	UNAUTHORIZED_COMMENT(404, "C40404", "댓글 권한이 없습니다"),
+
 
 	// 서버 오류
 	INTERNAL_SERVER_ERROR(500, "S50001", "서버 내부 오류가 발생했습니다.");

--- a/src/main/java/tave/crezipsa/crezipsa/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/tave/crezipsa/crezipsa/global/security/JwtAuthenticationFilter.java
@@ -57,23 +57,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     //Bearer 인증 방식
-    private String resolveToken (HttpServletRequest request){
-
+    private String resolveToken (HttpServletRequest request) {
         String bearer = request.getHeader("Authorization");
+
         if (bearer != null && bearer.startsWith("Bearer ")) {
             return bearer.substring(7);
         }
-
         return null;
-        //토큰 헤더 관련 예외처리
-        //   String bearer = request.getHeader("Authorization");
-//
-//
-//            if(bearer == null){ throw  new CommonException(ErrorCode.MISSING_AUTH_HEADER);}
-//            if (!bearer.startsWith("Bearer ")) { throw  new CommonException(ErrorCode.INVALID_TOKEN);
-//                 }
-//
-//            return bearer.substring(7);
     }
-        
 }

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/user/mapper/UserMapper.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/user/mapper/UserMapper.java
@@ -17,9 +17,10 @@ public class UserMapper {
                 .profileImageUrl(e.getProfileImageUrl())
                 .role(e.getRole())
                 .birth(e.getBirth())
-                .activeYotube(e.getActiveYoutube())
+                .activeYoutube(e.getActiveYoutube())
                 .activeTiktok(e.getActiveTiktok())
                 .activeInsta(e.getActiveInsta())
+                .mainPlatform(e.getMainPlatform())
                 .build();
     }
     public static UserJpaEntity toJpaUserEntity(User d) {
@@ -33,9 +34,10 @@ public class UserMapper {
                 .profileImageUrl(d.getProfileImageUrl())
                 .role(d.isRole())
                 .birth(d.getBirth())
-                .activeYoutube(d.getActiveYotube())
+                .activeYoutube(d.getActiveYoutube())
                 .activeTiktok(d.getActiveTiktok())
                 .activeInsta(d.getActiveInsta())
+                .mainPlatform(d.getMainPlatform())
                 .build();
     }
 

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/user/repository/UserInterestJpaRepository.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/user/repository/UserInterestJpaRepository.java
@@ -1,0 +1,15 @@
+package tave.crezipsa.crezipsa.infrastructure.user.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import tave.crezipsa.crezipsa.domain.user.entity.UserInterest;
+
+import java.util.List;
+
+
+public interface UserInterestJpaRepository extends JpaRepository<UserInterest, Long> {
+    List<UserInterest> findAllByUserId(Long userId);
+    UserInterest save(UserInterest userInterest);
+    UserInterest deleteByInterestIdAndUserId(Long interestId, Long userId);
+}

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/user/repository/UserInterestJpaRepository.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/user/repository/UserInterestJpaRepository.java
@@ -1,15 +1,16 @@
 package tave.crezipsa.crezipsa.infrastructure.user.repository;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 import tave.crezipsa.crezipsa.domain.user.entity.UserInterest;
 
 import java.util.List;
+import java.util.Optional;
 
 
 public interface UserInterestJpaRepository extends JpaRepository<UserInterest, Long> {
     List<UserInterest> findAllByUserId(Long userId);
     UserInterest save(UserInterest userInterest);
-    UserInterest deleteByInterestIdAndUserId(Long interestId, Long userId);
+    Boolean deleteByInterestId(Long interestId);
+    boolean existsByUserIdAndCategory(Long userId, String category);
+    Optional<UserInterest> findByUserIdAndCategory(Long userId, String category);
 }

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/user/repository/UserInterestJpaRepository.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/user/repository/UserInterestJpaRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 public interface UserInterestJpaRepository extends JpaRepository<UserInterest, Long> {
     List<UserInterest> findAllByUserId(Long userId);
     UserInterest save(UserInterest userInterest);
-    Boolean deleteByInterestId(Long interestId);
     boolean existsByUserIdAndCategory(Long userId, String category);
     Optional<UserInterest> findByUserIdAndCategory(Long userId, String category);
+    void deleteByInterestId(Long interestId);
 }

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/user/repository/UserInterestRepositoryImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/user/repository/UserInterestRepositoryImpl.java
@@ -6,6 +6,7 @@ import tave.crezipsa.crezipsa.domain.user.entity.UserInterest;
 import tave.crezipsa.crezipsa.domain.user.repository.UserInterestRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 @RequiredArgsConstructor
@@ -19,8 +20,8 @@ public class UserInterestRepositoryImpl implements UserInterestRepository {
     }
 
     @Override
-    public UserInterest deleteByUserInterestIdAndUserId(Long interestId, Long userId){
-        return userInterestJpaRepository.deleteByInterestIdAndUserId(interestId,userId);
+    public Boolean deleteByInterestId(Long interestId) {
+        return userInterestJpaRepository.deleteByInterestId(interestId);
     }
 
     @Override
@@ -28,4 +29,13 @@ public class UserInterestRepositoryImpl implements UserInterestRepository {
         return userInterestJpaRepository.findAllByUserId(userId);
     }
 
+    @Override
+    public Boolean existsByUserIdAndCategory(Long userId, String category) {
+        return userInterestJpaRepository.existsByUserIdAndCategory(userId, category);
+    }
+
+    @Override
+    public Optional<UserInterest> findByUserIdAndCategoryId(Long userId, String category) {
+        return userInterestJpaRepository.findByUserIdAndCategory(userId, category);
+    }
 }

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/user/repository/UserInterestRepositoryImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/user/repository/UserInterestRepositoryImpl.java
@@ -20,8 +20,8 @@ public class UserInterestRepositoryImpl implements UserInterestRepository {
     }
 
     @Override
-    public Boolean deleteByInterestId(Long interestId) {
-        return userInterestJpaRepository.deleteByInterestId(interestId);
+    public void deleteByInterestId(Long interestId) {
+        userInterestJpaRepository.deleteByInterestId(interestId);
     }
 
     @Override

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/user/repository/UserInterestRepositoryImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/user/repository/UserInterestRepositoryImpl.java
@@ -33,9 +33,9 @@ public class UserInterestRepositoryImpl implements UserInterestRepository {
     public Boolean existsByUserIdAndCategory(Long userId, String category) {
         return userInterestJpaRepository.existsByUserIdAndCategory(userId, category);
     }
-
+    
     @Override
-    public Optional<UserInterest> findByUserIdAndCategoryId(Long userId, String category) {
-        return userInterestJpaRepository.findByUserIdAndCategory(userId, category);
+    public Boolean existByInterestId(Long interestId){
+        return userInterestJpaRepository.existsById(interestId);
     }
 }

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/user/repository/UserInterestRepositoryImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/user/repository/UserInterestRepositoryImpl.java
@@ -1,0 +1,31 @@
+package tave.crezipsa.crezipsa.infrastructure.user.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import tave.crezipsa.crezipsa.domain.user.entity.UserInterest;
+import tave.crezipsa.crezipsa.domain.user.repository.UserInterestRepository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class UserInterestRepositoryImpl implements UserInterestRepository {
+
+    private final UserInterestJpaRepository userInterestJpaRepository;
+
+    @Override
+    public UserInterest save(UserInterest userInterest) {
+        return userInterestJpaRepository.save(userInterest);
+    }
+
+    @Override
+    public UserInterest deleteByUserInterestIdAndUserId(Long interestId, Long userId){
+        return userInterestJpaRepository.deleteByInterestIdAndUserId(interestId,userId);
+    }
+
+    @Override
+    public List<UserInterest> findAllByUserId(Long userId) {
+        return userInterestJpaRepository.findAllByUserId(userId);
+    }
+
+}

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/user/repository/UserJpaRepository.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/user/repository/UserJpaRepository.java
@@ -13,6 +13,7 @@ public interface UserJpaRepository extends JpaRepository<UserJpaEntity, Long> {
     Optional<UserJpaEntity> findById(Long userId);
     Optional<UserJpaEntity> findByNickName(String nickName);
 
+    UserJpaEntity save(UserJpaEntity user);
     Boolean existsByEmail(String email);
     Boolean existsByNickName(String nickName);
 }

--- a/src/main/java/tave/crezipsa/crezipsa/presentation/user/controller/UserController.java
+++ b/src/main/java/tave/crezipsa/crezipsa/presentation/user/controller/UserController.java
@@ -5,8 +5,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import tave.crezipsa.crezipsa.application.user.dto.request.UserInterestRequest;
 import tave.crezipsa.crezipsa.application.user.dto.request.UserSignUpRequest;
 import tave.crezipsa.crezipsa.application.user.dto.request.UserUpdateRequest;
+import tave.crezipsa.crezipsa.application.user.dto.response.UserInterestResponse;
 import tave.crezipsa.crezipsa.application.user.dto.response.UserSignUpResponse;
 import tave.crezipsa.crezipsa.application.user.usecase.UserUsecase;
 import tave.crezipsa.crezipsa.domain.user.entity.User;
@@ -36,4 +38,19 @@ public class UserController {
         return GlobalResponseDto.success();
     }
 
+    @PostMapping("/interest")
+    public GlobalResponseDto insertInterest(
+            @AuthenticationPrincipal User user, @Valid @RequestBody UserInterestRequest request){
+
+        UserInterestResponse interestResponse = userUsecase.addUserInterest(user.getUserId(),request);
+        return GlobalResponseDto.success(interestResponse);
+    }
+
+    @DeleteMapping("/interest")
+    public GlobalResponseDto deleteInterest(
+            @AuthenticationPrincipal User user, @Valid @RequestBody UserInterestRequest request){
+
+        userUsecase.deleteUserInterest(user.getUserId(),request);
+        return GlobalResponseDto.success();
+    }
 }

--- a/src/main/java/tave/crezipsa/crezipsa/presentation/user/controller/UserController.java
+++ b/src/main/java/tave/crezipsa/crezipsa/presentation/user/controller/UserController.java
@@ -12,7 +12,10 @@ import tave.crezipsa.crezipsa.application.user.dto.response.UserInterestResponse
 import tave.crezipsa.crezipsa.application.user.dto.response.UserSignUpResponse;
 import tave.crezipsa.crezipsa.application.user.usecase.UserUsecase;
 import tave.crezipsa.crezipsa.domain.user.entity.User;
+import tave.crezipsa.crezipsa.domain.user.entity.UserInterest;
 import tave.crezipsa.crezipsa.global.common.dto.GlobalResponseDto;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/user")
@@ -52,5 +55,13 @@ public class UserController {
 
         userUsecase.deleteUserInterest(user.getUserId(),request);
         return GlobalResponseDto.success();
+    }
+
+    @GetMapping("/interest")
+    public GlobalResponseDto getInterest(
+            @AuthenticationPrincipal User user, @Valid UserInterestRequest request){
+
+        List<UserInterestResponse> userInterest =  userUsecase.getUserInterest(user.getUserId());
+        return GlobalResponseDto.success(userInterest);
     }
 }

--- a/src/main/java/tave/crezipsa/crezipsa/presentation/user/controller/UserController.java
+++ b/src/main/java/tave/crezipsa/crezipsa/presentation/user/controller/UserController.java
@@ -53,7 +53,7 @@ public class UserController {
     public GlobalResponseDto deleteInterest(
             @AuthenticationPrincipal User user, @Valid @RequestBody UserInterestRequest request){
 
-        userUsecase.deleteUserInterest(user.getUserId(),request);
+        userUsecase.deleteUserInterest(request);
         return GlobalResponseDto.success();
     }
 

--- a/src/main/java/tave/crezipsa/crezipsa/presentation/user/controller/UserController.java
+++ b/src/main/java/tave/crezipsa/crezipsa/presentation/user/controller/UserController.java
@@ -2,12 +2,14 @@ package tave.crezipsa.crezipsa.presentation.user.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import tave.crezipsa.crezipsa.application.user.dto.request.UserSignUpRequest;
 import tave.crezipsa.crezipsa.application.user.dto.request.UserUpdateRequest;
 import tave.crezipsa.crezipsa.application.user.dto.response.UserSignUpResponse;
 import tave.crezipsa.crezipsa.application.user.usecase.UserUsecase;
+import tave.crezipsa.crezipsa.domain.user.entity.User;
 import tave.crezipsa.crezipsa.global.common.dto.GlobalResponseDto;
 
 @RestController
@@ -27,9 +29,10 @@ public class UserController {
     }
 
     @PatchMapping("/update")
-    public GlobalResponseDto<UserUpdateRequest> update(
-            @Valid @RequestBody UserUpdateRequest request){
+    public GlobalResponseDto update(
+            @AuthenticationPrincipal User user, @Valid @RequestBody UserUpdateRequest request){
 
+        userUsecase.update(user.getUserId(),request);
         return GlobalResponseDto.success();
     }
 


### PR DESCRIPTION
## 📌 작업한 내용
1. 사용자 정보 수정하는 기능을 개발하였습니다. 
- PATCH 로 사용자 플랫폼별 아이디/링크, 대표 플랫폼 정보 수정

2. 사용자 관심 카테고리 추가/삭제/조회 기능을 개발하였습니다.

- 카테고리 추가(POST) -추가하고자 하는 카테고리가 있는지 확인 -> 있을 시 ALREDY_INTEREST 예외 발생
-> 없으면 추가 
- 카테고리 삭제(DELETE) -삭제하고자 하는 카테고리 있는지 확인 -> 없을 시 INVALID_INTEREST 예외 발
 -> 있으면 삭제 
- 카테고리 조회(GET) - UerId로 조회 

## 🔍 참고 사항
- UserInterest 엔티티에서 User와의 연관관계는 DDD 관점에서 결합도를 낮추기 위해
  직접 매핑(@ManyToOne) 대신 ID 참조 방식으로 설계했습니다.

- JPA 레벨에서는 @Column(name = "user_id")로 단순 값 매핑만 하고 있으며  
  DB에서는 User테이블의 user_id를 참조하는 외래 키 컬럼으로 사용합니다.

-사용자 관련 기능(User 도메인)에서 카테고리 조회/삭제 로직을 처리하고 있는데,
추후 트렌드(Trend) 기능을 개발하게 되면 해당 로직을 Trend 쪽으로 이동해도 좋을 것 같습니다.

## 🖼️ 스크린샷
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9cf79372-e312-4ccf-aefe-665d29803173" />
<회원 정보 수정>

<img width="1920" height="1080" alt="스크린샷(10)" src="https://github.com/user-attachments/assets/3dbce22e-adf9-4f34-96d5-ff351a02cfc3" />
<관심 카테고리 추가>

<img width="1920" height="1080" alt="스크린샷(11)" src="https://github.com/user-attachments/assets/58809af0-661c-4ed2-ad2a-e4e43948833d" />
<관심 카테고리 조회>

<img width="1919" height="1072" alt="image" src="https://github.com/user-attachments/assets/85e5cd19-2006-4ab0-b39c-7c111ce64238" />
<관심 카테고리 삭제>


## 🔗 관련 이슈
#19 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인