### PR TITLE
Feat/#26/실시간트렌드조회개발

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // JSON 직렬화용
 
+    //jdbc
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/tave/crezipsa/crezipsa/application/chat/dto/request/ChatMessageRequest.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/chat/dto/request/ChatMessageRequest.java
@@ -1,0 +1,7 @@
+package tave.crezipsa.crezipsa.application.chat.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ChatMessageRequest(
+	@NotBlank String message
+) { }

--- a/src/main/java/tave/crezipsa/crezipsa/application/chat/dto/response/GeminiChatResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/chat/dto/response/GeminiChatResponse.java
@@ -1,0 +1,6 @@
+package tave.crezipsa.crezipsa.application.chat.dto.response;
+
+public record GeminiChatResponse(
+	String content
+) {
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/chat/usecase/ChatUseCase.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/chat/usecase/ChatUseCase.java
@@ -1,0 +1,10 @@
+package tave.crezipsa.crezipsa.application.chat.usecase;
+
+import tave.crezipsa.crezipsa.application.chat.dto.response.GeminiChatResponse;
+import tave.crezipsa.crezipsa.application.storyboard.dto.response.StoryboardStructuredResponse;
+
+public interface ChatUseCase {
+
+	Long createChatRoom ( Long userId, String title);
+	GeminiChatResponse sendUserMessage(Long chatRoomId, Long userId, String message);
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/chat/usecase/ChatUseCaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/chat/usecase/ChatUseCaseImpl.java
@@ -1,0 +1,50 @@
+package tave.crezipsa.crezipsa.application.chat.usecase;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import tave.crezipsa.crezipsa.application.chat.dto.response.GeminiChatResponse;
+import tave.crezipsa.crezipsa.domain.chat.entity.ChatMessage;
+import tave.crezipsa.crezipsa.domain.chat.entity.ChatRoom;
+import tave.crezipsa.crezipsa.domain.chat.port.ChatMessageRepositoryPort;
+import tave.crezipsa.crezipsa.domain.chat.port.ChatRoomRepositoryPort;
+import tave.crezipsa.crezipsa.domain.storyboard.port.StoryboardGeneratorPort;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ChatUseCaseImpl implements ChatUseCase {
+
+	private final ChatRoomRepositoryPort chatRoomRepository;
+	private final ChatMessageRepositoryPort chatMessageRepository;
+	private final StoryboardGeneratorPort storyboardGeneratorPort;
+
+
+
+	@Override
+	public Long createChatRoom(Long userId, String title) {
+		String checkTitle = resolveChatRooomTitle(title);
+		ChatRoom room = ChatRoom.create(userId, checkTitle);
+		return chatRoomRepository.save(room).getId();
+	}
+
+	@Override
+	public GeminiChatResponse sendUserMessage(Long chatRoomId, Long userId, String message) {
+
+		chatMessageRepository.save(ChatMessage.fromUser(chatRoomId,message));
+
+		String aiReply = storyboardGeneratorPort.generate(message);
+
+		chatMessageRepository.save(ChatMessage.fromAI(chatRoomId, aiReply));
+
+		return new GeminiChatResponse(aiReply);
+	}
+
+	private String resolveChatRooomTitle(String title) {
+		return (title == null || title.isBlank())
+			? "새 채팅"
+			: title;
+	}
+
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/storyboard/dto/request/SaveStoryboardRequest.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/storyboard/dto/request/SaveStoryboardRequest.java
@@ -1,0 +1,9 @@
+package tave.crezipsa.crezipsa.application.storyboard.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record SaveStoryboardRequest(
+	@NotNull Long chatMessageId,
+	String title
+) {
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/storyboard/dto/request/UpdateStoryboardRequest.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/storyboard/dto/request/UpdateStoryboardRequest.java
@@ -1,0 +1,10 @@
+package tave.crezipsa.crezipsa.application.storyboard.dto.request;
+
+public record UpdateStoryboardRequest(
+	String title,
+	String cutSummary,
+	String script,
+	String caption,
+	String time
+) {
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/storyboard/dto/response/StoryboardStructuredResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/storyboard/dto/response/StoryboardStructuredResponse.java
@@ -1,0 +1,20 @@
+package tave.crezipsa.crezipsa.application.storyboard.dto.response;
+
+import tave.crezipsa.crezipsa.domain.storyboard.entity.Storyboard;
+
+public record StoryboardStructuredResponse(
+	String cutSummary,
+	String script,
+	String caption,
+	String time
+) {
+
+	public static StoryboardStructuredResponse from(Storyboard storyboard) {
+		return new StoryboardStructuredResponse(
+			storyboard.getCutSummary(),
+			storyboard.getScript(),
+			storyboard.getCaption(),
+			storyboard.getTime()
+		);
+	}
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/storyboard/dto/response/StoryboardSummaryResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/storyboard/dto/response/StoryboardSummaryResponse.java
@@ -1,0 +1,11 @@
+package tave.crezipsa.crezipsa.application.storyboard.dto.response;
+
+import java.time.LocalDateTime;
+
+public record StoryboardSummaryResponse(
+	Long storyboardId,
+	String title,
+	LocalDateTime createdAt
+
+) {
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/storyboard/usecase/StoryboardUsecase.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/storyboard/usecase/StoryboardUsecase.java
@@ -1,0 +1,17 @@
+package tave.crezipsa.crezipsa.application.storyboard.usecase;
+
+import java.util.List;
+
+import tave.crezipsa.crezipsa.application.storyboard.dto.request.UpdateStoryboardRequest;
+import tave.crezipsa.crezipsa.application.storyboard.dto.response.StoryboardStructuredResponse;
+import tave.crezipsa.crezipsa.application.storyboard.dto.response.StoryboardSummaryResponse;
+
+public interface StoryboardUsecase {
+	StoryboardStructuredResponse createFromChatMessage(Long userId, Long chatMessageId, String title);
+
+	StoryboardStructuredResponse get(Long userId, Long storyboardId);
+	List<StoryboardSummaryResponse> getMyList(Long userId);
+
+	StoryboardStructuredResponse update(Long userId, Long storyboardId, UpdateStoryboardRequest request);
+	void delete(Long userId, Long storyboardId);
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/storyboard/usecase/StoryboardUsecaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/storyboard/usecase/StoryboardUsecaseImpl.java
@@ -1,0 +1,131 @@
+package tave.crezipsa.crezipsa.application.storyboard.usecase;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import tave.crezipsa.crezipsa.application.storyboard.dto.request.UpdateStoryboardRequest;
+import tave.crezipsa.crezipsa.application.storyboard.dto.response.StoryboardStructuredResponse;
+import tave.crezipsa.crezipsa.application.storyboard.dto.response.StoryboardSummaryResponse;
+import tave.crezipsa.crezipsa.domain.chat.entity.ChatMessage;
+import tave.crezipsa.crezipsa.domain.chat.port.ChatMessageRepositoryPort;
+import tave.crezipsa.crezipsa.domain.storyboard.entity.Storyboard;
+import tave.crezipsa.crezipsa.domain.storyboard.port.StoryboardRepositoryPort;
+import tave.crezipsa.crezipsa.domain.storyboard.port.StoryboardStructurerPort;
+import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
+import tave.crezipsa.crezipsa.global.exception.model.CommonException;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class StoryboardUsecaseImpl implements StoryboardUsecase {
+
+	private final StoryboardRepositoryPort storyboardRepository;
+	private final ChatMessageRepositoryPort chatMessageRepository;
+	private final StoryboardStructurerPort storyboardStructurerPort;
+
+	@Override
+	public StoryboardStructuredResponse createFromChatMessage(
+		Long userId,
+		Long chatMessageId,
+		String title
+	) {
+		ChatMessage message = chatMessageRepository.findById(chatMessageId);
+
+		if (message == null) {
+			throw new CommonException(ErrorCode.CHAT_NOT_FOUND);
+		}
+
+		if (message.getSenderType() != ChatMessage.SenderType.AI) {
+			throw new CommonException(ErrorCode.INVALID_SENDER_TYPE);
+		}
+
+		StoryboardStructuredResponse structured =
+			storyboardStructurerPort.structure(message.getContent());
+
+		Storyboard storyboard = Storyboard.create(
+			userId,
+			(title == null || title.isBlank()) ? "AI 스토리보드" : title,
+			structured.cutSummary(),
+			structured.script(),
+			structured.caption(),
+			structured.time()
+		);
+
+		storyboardRepository.save(storyboard);
+
+		return structured;
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public StoryboardStructuredResponse get(Long userId, Long storyboardId) {
+		Storyboard storyboard = storyboardRepository.findById(storyboardId);
+
+		if (storyboard == null || !storyboard.getUserId().equals(userId)) {
+			throw new CommonException(ErrorCode.STORYBOARD_NOT_FOUND);
+		}
+
+		return StoryboardStructuredResponse.from(storyboard);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public List<StoryboardSummaryResponse> getMyList(Long userId) {
+		return storyboardRepository.findByUserId(userId)
+			.stream()
+			.map(sb -> new StoryboardSummaryResponse(
+				sb.getId(),
+				sb.getTitle(),
+				sb.getCreatedAt()
+			))
+			.toList();
+	}
+
+	@Override
+	public StoryboardStructuredResponse update(
+		Long userId,
+		Long storyboardId,
+		UpdateStoryboardRequest request
+	) {
+		Storyboard storyboard = storyboardRepository.findById(storyboardId);
+
+		if (storyboard == null || !storyboard.getUserId().equals(userId)) {
+			throw new CommonException(ErrorCode.STORYBOARD_NOT_FOUND);
+		}
+
+		Storyboard updated = Storyboard.builder()
+			.id(storyboard.getId())
+			.userId(storyboard.getUserId())
+			.title(request.title() != null ? request.title() : storyboard.getTitle())
+			.cutSummary(request.cutSummary() != null ? request.cutSummary() : storyboard.getCutSummary())
+			.script(request.script() != null ? request.script() : storyboard.getScript())
+			.caption(request.caption() != null ? request.caption() : storyboard.getCaption())
+			.time(request.time() != null ? request.time() : storyboard.getTime())
+			.createdAt(storyboard.getCreatedAt())
+			.build();
+
+		storyboardRepository.save(updated);
+
+		return new StoryboardStructuredResponse(
+			updated.getCutSummary(),
+			updated.getScript(),
+			updated.getCaption(),
+			updated.getTime()
+		);
+	}
+
+
+	@Override
+	public void delete(Long userId, Long storyboardId) {
+		Storyboard storyboard = storyboardRepository.findById(storyboardId);
+
+		if (storyboard == null || !storyboard.getUserId().equals(userId)) {
+			throw new CommonException(ErrorCode.STORYBOARD_NOT_FOUND);
+		}
+
+		storyboardRepository.deleteById(storyboardId);
+	}
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/trend/dto/response/TrendResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/trend/dto/response/TrendResponse.java
@@ -1,0 +1,21 @@
+package tave.crezipsa.crezipsa.application.trend.dto.response;
+
+import tave.crezipsa.crezipsa.domain.user.enums.Platform;
+import tave.crezipsa.crezipsa.infrastructure.trend.TrendRow;
+
+public record TrendResponse(
+
+        Long id,
+        String keyword,
+        int rank,
+        Platform platform
+) {
+    public static TrendResponse from(TrendRow row) {
+        return new TrendResponse(
+                row.id(),
+                row.keyword(),
+                row.rank(),
+                Platform.valueOf(row.platform()) // String → enum
+        );
+    }
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/trend/port/TrendQueryPort.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/trend/port/TrendQueryPort.java
@@ -1,0 +1,14 @@
+package tave.crezipsa.crezipsa.application.trend.port;
+
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import tave.crezipsa.crezipsa.application.trend.dto.response.TrendResponse;
+import tave.crezipsa.crezipsa.domain.user.enums.Platform;
+import tave.crezipsa.crezipsa.infrastructure.trend.TrendRow;
+
+import java.util.List;
+
+public interface TrendQueryPort {
+    List<TrendRow> findTopKeywordsByPlatform(String platform);
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/trend/usecase/TrendUsecase.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/trend/usecase/TrendUsecase.java
@@ -1,0 +1,12 @@
+package tave.crezipsa.crezipsa.application.trend.usecase;
+
+import tave.crezipsa.crezipsa.application.trend.dto.response.TrendResponse;
+import tave.crezipsa.crezipsa.domain.user.enums.Platform;
+
+import java.util.List;
+
+
+public interface TrendUsecase {
+
+    List<TrendResponse> execute(String platform);
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/trend/usecase/TrendUsecaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/trend/usecase/TrendUsecaseImpl.java
@@ -1,0 +1,32 @@
+package tave.crezipsa.crezipsa.application.trend.usecase;
+
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import tave.crezipsa.crezipsa.application.trend.dto.response.TrendResponse;
+import tave.crezipsa.crezipsa.application.trend.port.TrendQueryPort;
+import tave.crezipsa.crezipsa.domain.user.enums.Platform;
+import tave.crezipsa.crezipsa.infrastructure.trend.TrendRow;
+
+import java.util.List;
+
+@Service
+@AllArgsConstructor
+@Transactional(readOnly = true)
+public class TrendUsecaseImpl implements TrendUsecase {
+
+    private final TrendQueryPort trendQueryPort;
+
+    @Override
+    public List<TrendResponse> execute(String platform) {
+
+        System.out.println(platform + "\n\n");
+
+        List<TrendRow> trendRowList = trendQueryPort.findTopKeywordsByPlatform(platform);
+        return trendRowList.stream()
+                .map(TrendResponse::from)
+                .toList();
+    }
+
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/trend/usecase/TrendUsecaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/trend/usecase/TrendUsecaseImpl.java
@@ -21,8 +21,6 @@ public class TrendUsecaseImpl implements TrendUsecase {
     @Override
     public List<TrendResponse> execute(String platform) {
 
-        System.out.println(platform + "\n\n");
-
         List<TrendRow> trendRowList = trendQueryPort.findTopKeywordsByPlatform(platform);
         return trendRowList.stream()
                 .map(TrendResponse::from)

--- a/src/main/java/tave/crezipsa/crezipsa/domain/chat/entity/ChatMessage.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/chat/entity/ChatMessage.java
@@ -1,0 +1,42 @@
+package tave.crezipsa.crezipsa.domain.chat.entity;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class ChatMessage {
+
+	public enum SenderType {
+		USER,
+		AI
+	}
+
+	private final Long id;
+	private final Long chatRoomId;
+	private final SenderType senderType;
+	private final String content;
+	private final LocalDateTime createdAt;
+
+	public static ChatMessage fromUser(Long chatRoomId, String content) {
+		return ChatMessage.builder()
+			.chatRoomId(chatRoomId)
+			.senderType(SenderType.USER)
+			.content(content)
+			.createdAt(LocalDateTime.now())
+			.build();
+	}
+
+	public static ChatMessage fromAI(Long chatRoomId, String content) {
+		return ChatMessage.builder()
+			.chatRoomId(chatRoomId)
+			.senderType(SenderType.AI)
+			.content(content)
+			.createdAt(LocalDateTime.now())
+			.build();
+	}
+}

--- a/src/main/java/tave/crezipsa/crezipsa/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/chat/entity/ChatRoom.java
@@ -1,0 +1,28 @@
+package tave.crezipsa.crezipsa.domain.chat.entity;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ChatRoom {
+
+	private final Long id;
+	private final Long userId;
+	private final String title;
+	private final LocalDateTime createdAt;
+
+	public static ChatRoom create(Long userId, String title) {
+		return ChatRoom.builder()
+			.userId(userId)
+			.title(title)
+			.createdAt(LocalDateTime.now())
+			.build();
+	}
+}
+
+

--- a/src/main/java/tave/crezipsa/crezipsa/domain/chat/port/ChatMessageRepositoryPort.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/chat/port/ChatMessageRepositoryPort.java
@@ -1,0 +1,13 @@
+package tave.crezipsa.crezipsa.domain.chat.port;
+
+import java.util.List;
+
+import tave.crezipsa.crezipsa.domain.chat.entity.ChatMessage;
+
+public interface ChatMessageRepositoryPort {
+
+	ChatMessage save(ChatMessage message);
+	List<ChatMessage> findByChatRoomId(Long chatRoomId);
+	ChatMessage findById(Long id);
+
+}

--- a/src/main/java/tave/crezipsa/crezipsa/domain/chat/port/ChatRoomRepositoryPort.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/chat/port/ChatRoomRepositoryPort.java
@@ -1,0 +1,12 @@
+package tave.crezipsa.crezipsa.domain.chat.port;
+
+import java.util.Optional;
+
+import tave.crezipsa.crezipsa.domain.chat.entity.ChatRoom;
+
+public interface ChatRoomRepositoryPort {
+
+	ChatRoom save(ChatRoom chatRoom);
+	Optional<ChatRoom> findById(Long chatRoomId);
+
+}

--- a/src/main/java/tave/crezipsa/crezipsa/domain/storyboard/entity/Storyboard.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/storyboard/entity/Storyboard.java
@@ -1,0 +1,37 @@
+package tave.crezipsa.crezipsa.domain.storyboard.entity;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class Storyboard {
+
+	private final Long id;
+	private final Long userId;
+
+	private final String title;
+
+	private final String cutSummary;
+	private final String script;
+	private final String caption;
+	private final String time;
+
+	private final LocalDateTime createdAt;
+
+	public static Storyboard create(Long userId, String title, String cutSummary, String script, String caption, String time) {
+		return Storyboard.builder()
+			.userId(userId)
+			.title(title)
+			.cutSummary(cutSummary)
+			.script(script)
+			.caption(caption)
+			.time(time)
+			.createdAt(LocalDateTime.now())
+			.build();
+	}
+}

--- a/src/main/java/tave/crezipsa/crezipsa/domain/storyboard/port/StoryboardGeneratorPort.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/storyboard/port/StoryboardGeneratorPort.java
@@ -1,0 +1,7 @@
+package tave.crezipsa.crezipsa.domain.storyboard.port;
+
+public interface StoryboardGeneratorPort {
+
+	String generate(String prompt);
+
+}

--- a/src/main/java/tave/crezipsa/crezipsa/domain/storyboard/port/StoryboardRepositoryPort.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/storyboard/port/StoryboardRepositoryPort.java
@@ -1,0 +1,14 @@
+package tave.crezipsa.crezipsa.domain.storyboard.port;
+
+import java.util.List;
+
+import tave.crezipsa.crezipsa.domain.storyboard.entity.Storyboard;
+
+public interface StoryboardRepositoryPort {
+
+	Storyboard save(Storyboard storyboard);
+	List<Storyboard> findByUserId(Long userId);
+	Storyboard findById(Long storyboardId);
+	void deleteById(Long storyboardId);
+
+}

--- a/src/main/java/tave/crezipsa/crezipsa/domain/storyboard/port/StoryboardStructurerPort.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/storyboard/port/StoryboardStructurerPort.java
@@ -1,0 +1,7 @@
+package tave.crezipsa.crezipsa.domain.storyboard.port;
+
+import tave.crezipsa.crezipsa.application.storyboard.dto.response.StoryboardStructuredResponse;
+
+public interface StoryboardStructurerPort {
+	StoryboardStructuredResponse structure(String aiMessageContent);
+}

--- a/src/main/java/tave/crezipsa/crezipsa/domain/user/enums/Platform.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/user/enums/Platform.java
@@ -2,6 +2,6 @@ package tave.crezipsa.crezipsa.domain.user.enums;
 
 public enum Platform {
     YOUTUBE,
-    INSTA,
+    INSTAGRAM,  //수정됨:
     TIKTOK
 }

--- a/src/main/java/tave/crezipsa/crezipsa/global/config/AnalyticsJdbcConfig.java
+++ b/src/main/java/tave/crezipsa/crezipsa/global/config/AnalyticsJdbcConfig.java
@@ -1,0 +1,37 @@
+package tave.crezipsa.crezipsa.global.config;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+import javax.sql.DataSource;
+
+@Configuration
+public class AnalyticsJdbcConfig {
+
+    @Bean@Qualifier("analyticsDataSourceProperties")
+    @ConfigurationProperties("analytics.datasource")
+    public DataSourceProperties analyticsDataSourceProperties() {
+        return new DataSourceProperties();
+    }
+
+    @Bean(name = "analyticsDataSource")
+    public DataSource analyticsDataSource(
+            @Qualifier("analyticsDataSourceProperties") DataSourceProperties props
+    ) {
+        return props.initializeDataSourceBuilder()
+                .type(HikariDataSource.class)
+                .build();
+    }
+
+    @Bean
+    public NamedParameterJdbcTemplate analyticsJdbc(
+            @Qualifier("analyticsDataSource") DataSource ds
+    ) {
+        return new NamedParameterJdbcTemplate(ds);
+    }
+}

--- a/src/main/java/tave/crezipsa/crezipsa/global/config/MainDataSourceConfig.java
+++ b/src/main/java/tave/crezipsa/crezipsa/global/config/MainDataSourceConfig.java
@@ -1,0 +1,28 @@
+package tave.crezipsa.crezipsa.global.config;
+
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import javax.sql.DataSource;
+
+@Configuration
+public class MainDataSourceConfig {
+
+    @Primary
+    @Bean
+    @ConfigurationProperties("spring.datasource")
+    public DataSourceProperties mainDataSourceProperties() {
+        return new DataSourceProperties();
+    }
+
+    @Primary
+    @Bean
+    public DataSource dataSource(DataSourceProperties mainDataSourceProperties) {
+        return mainDataSourceProperties.initializeDataSourceBuilder()
+                .type(com.zaxxer.hikari.HikariDataSource.class)
+                .build();
+    }
+}

--- a/src/main/java/tave/crezipsa/crezipsa/global/config/SecurityConfig.java
+++ b/src/main/java/tave/crezipsa/crezipsa/global/config/SecurityConfig.java
@@ -37,7 +37,6 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()// 로그인 관련 API는 인증 없이 접근 가능
                         .requestMatchers("/api/user/signUp").permitAll()
-                        //.requestMatchers("/api/likes/**").permitAll()
                         .anyRequest().authenticated()             // 그 외는 인증 필요
                 )
 

--- a/src/main/java/tave/crezipsa/crezipsa/global/config/SecurityConfig.java
+++ b/src/main/java/tave/crezipsa/crezipsa/global/config/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()// 로그인 관련 API는 인증 없이 접근 가능
                         .requestMatchers("/api/user/signUp").permitAll()
+                        //.requestMatchers("/api/likes/**").permitAll()
                         .anyRequest().authenticated()             // 그 외는 인증 필요
                 )
 

--- a/src/main/java/tave/crezipsa/crezipsa/global/exception/code/ErrorCode.java
+++ b/src/main/java/tave/crezipsa/crezipsa/global/exception/code/ErrorCode.java
@@ -8,7 +8,7 @@ public enum ErrorCode implements BaseErrorCode {
 	USER_INVALID_ROLE(401, "U40101","권한이 없는 사용자입니다."),
 	USER_INVALID_ID(401,"U40102", "존재하지 않는 유저입니다."),
 
-
+	//카테고리 관련
 	INVALD_INTEREST(404,"I40401", "존재하지 않은 사용자 관심 카테고리입니다."),
 	ALREADY_INTEREST(400,"I40001","이미 선택한 사용자 관심 카테고리입니다."),
 
@@ -18,6 +18,16 @@ public enum ErrorCode implements BaseErrorCode {
 	INVALID_REFRESH_TOKEN(401, "A40103", "토큰이 일치하지 않습니다."),
 	ACCESS_TOKEN_EXPIRED(401,"A40104","토큰 유효시간이 만료되었습니다."),
 	KAKAO_USERINFO_FAILED(400, "A40105", "카카오 사용자 정보를 가져오지 못했습니다."),
+
+	// 스토리보드 관련
+	INVALID_SENDER_TYPE(401,"S40101", "Sender TYPE이 올바르지 않습니다."),
+	STORYBOARD_NOT_FOUND(404, "S40401", "존재하지 않는 스토리보드입니다."),
+
+	//제미나이 관련
+	GEMINI_EMPTY_RESPONSE(404,"G40401", "제미나이 응답 오류입니다."),
+	GEMINI_CLIENT_ERROR(400, "G40001", "Gemini 요청 값이 올바르지 않습니다."),
+	GEMINI_SERVER_ERROR(502, "G50202", "Gemini 서버 오류가 발생했습니다."),
+	GEMINI_REQUEST_FAILED(504, "G50401", "Gemini 요청 처리 중 오류가 발생했습니다."),
 
 	// 커뮤니티 관련
 	COMMUNITY_NOT_FOUND(404, "C40401", "해당 커뮤니티 게시글을 찾을 수 없습니다."),
@@ -30,6 +40,9 @@ public enum ErrorCode implements BaseErrorCode {
 	NOT_LIKED(400,"C40003", "좋아요를 누르지 않은 글입니다."),
 	UNAUTHORIZED_COMMUNITY(404, "C40403", "게시글 권한이 없습니다"),
 	UNAUTHORIZED_COMMENT(404, "C40404", "댓글 권한이 없습니다"),
+
+	//스토리보드 관련
+	CHAT_NOT_FOUND(404, "C40405", "대화내역이 존재하지 않습니다"),
 
 
 	// 서버 오류

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/entity/ChatMessageJpaEntity.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/entity/ChatMessageJpaEntity.java
@@ -1,0 +1,42 @@
+package tave.crezipsa.crezipsa.infrastructure.chat.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import tave.crezipsa.crezipsa.domain.chat.entity.ChatMessage;
+
+@Entity
+@Table(name = "chat_message")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ChatMessageJpaEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long messageId;
+
+	private Long chatRoomId;
+
+	@Enumerated(EnumType.STRING)
+	private SenderType senderType;
+
+	@Column(columnDefinition = "TEXT")
+	private String content;
+
+	public enum SenderType {
+		USER, AI
+	}
+
+}

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/entity/ChatRoomJpaEntity.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/entity/ChatRoomJpaEntity.java
@@ -1,0 +1,30 @@
+package tave.crezipsa.crezipsa.infrastructure.chat.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "chat")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ChatRoomJpaEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long chatRoomId;
+
+	private Long userId;
+
+	private String chatTitle;
+
+}

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/gemini/GeminiStoryboardGenerator.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/gemini/GeminiStoryboardGenerator.java
@@ -1,0 +1,84 @@
+package tave.crezipsa.crezipsa.infrastructure.chat.gemini;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+import tave.crezipsa.crezipsa.domain.storyboard.port.StoryboardGeneratorPort;
+import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
+import tave.crezipsa.crezipsa.global.exception.model.CommonException;
+
+@Component
+@RequiredArgsConstructor
+public class GeminiStoryboardGenerator implements StoryboardGeneratorPort {
+
+	@Value("${gemini.api-key}")
+	private String apiKey;
+
+	@Value("${gemini.url:https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent}")
+	private String url;
+
+	private final WebClient webClient = WebClient.create();
+
+	@Override
+	public String generate(String prompt) {
+
+		Map<String, Object> body = Map.of(
+			"contents", new Object[]{
+				Map.of(
+					"parts", new Object[]{
+						Map.of("text", prompt)
+					}
+				)
+			}
+		);
+
+		String result = webClient.post()
+			.uri(url + "?key=" + apiKey)
+			.bodyValue(body)
+			.retrieve()
+			.onStatus(
+				status -> status.is4xxClientError(),
+				response -> Mono.error(new CommonException(ErrorCode.GEMINI_CLIENT_ERROR))
+			)
+			.onStatus(
+				status -> status.is5xxServerError(),
+				response -> Mono.error(new CommonException(ErrorCode.GEMINI_SERVER_ERROR))
+			)
+			.bodyToMono(Map.class)
+			.map(response -> {
+				var candidates = (List<Map<String, Object>>) response.get("candidates");
+				if (candidates == null || candidates.isEmpty()) {
+					throw new CommonException(ErrorCode.GEMINI_EMPTY_RESPONSE);
+				}
+
+				var content = (Map<String, Object>) candidates.get(0).get("content");
+				var parts = (List<Map<String, String>>) content.get("parts");
+
+				if (parts == null || parts.isEmpty()
+					|| !org.springframework.util.StringUtils.hasText(parts.get(0).get("text"))) {
+					throw new CommonException(ErrorCode.GEMINI_EMPTY_RESPONSE);
+				}
+
+
+				return parts.get(0).get("text");
+			})
+			.onErrorMap(
+				WebClientResponseException.class,
+				ex -> new CommonException(ErrorCode.GEMINI_REQUEST_FAILED)
+			)
+			.block();
+
+		if (!org.springframework.util.StringUtils.hasText(result)) {
+			throw new CommonException(ErrorCode.GEMINI_EMPTY_RESPONSE);
+		}
+
+		return result;
+	}
+}

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/gemini/GeminiStroyboardStructurer.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/gemini/GeminiStroyboardStructurer.java
@@ -1,0 +1,126 @@
+package tave.crezipsa.crezipsa.infrastructure.chat.gemini;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import tave.crezipsa.crezipsa.application.storyboard.dto.response.StoryboardStructuredResponse;
+import tave.crezipsa.crezipsa.domain.storyboard.port.StoryboardStructurerPort;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GeminiStroyboardStructurer implements StoryboardStructurerPort {
+
+	@Value("${gemini.api-key}")
+	private String apiKey;
+
+	@Value("${gemini.url:https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent}")
+	private String url;
+
+	private final WebClient webClient = WebClient.create();
+	private final ObjectMapper om = new ObjectMapper();
+
+	@Override
+	public StoryboardStructuredResponse structure(String aiMessageContent) {
+
+		// 프롬프트: JSON 포맷을 강제하는 강력한 지시사항
+		String prompt = """
+        역할: 너는 전문 영상 기획자다.
+        임무: 아래 입력된 텍스트 내용을 바탕으로 영상 촬영을 위한 '스토리보드' 정보 하나를 추출해라.
+        
+        [출력 포맷]
+        반드시 아래 JSON 형식으로만 출력해. 마크다운 코드 블록(```json)이나 잡담은 절대 포함하지 마.
+        {
+          "cutSummary": "해당 컷의 핵심 요약 (1문장)",
+          "script": "영상에서 실제로 말해야 할 대사나 내레이션",
+          "caption": "화면에 띄울 자막 내용",
+          "time": "예상 소요 시간 (예: 5초)"
+        }
+
+        [입력 텍스트]
+        """ + aiMessageContent;
+
+		String safeUrl = url.trim();
+		String safeKey = apiKey.trim();
+
+		// ★ 중요: URI 객체로 변환하여 인코딩 방지
+		URI uri = URI.create(safeUrl + "?key=" + safeKey);
+
+		Map<String, Object> body = Map.of(
+			"contents", new Object[]{
+				Map.of("parts", new Object[]{
+					Map.of("text", prompt)
+				})
+			}
+		);
+
+		// 1. 요청 및 원본 텍스트 수신
+		String rawResponse = webClient.post()
+			.uri(uri)
+			.header("Content-Type", "application/json")
+			.bodyValue(body)
+			.retrieve()
+			.bodyToMono(Map.class)
+			.map(response -> {
+				try {
+					var candidates = (List<Map<String, Object>>) response.get("candidates");
+					var content = (Map<String, Object>) candidates.get(0).get("content");
+					var parts = (List<Map<String, String>>) content.get("parts");
+					return parts.get(0).get("text");
+				} catch (Exception e) {
+					log.error("Gemini Structurer 응답 파싱 실패: {}", response);
+					throw new RuntimeException("Gemini Parsing Error");
+				}
+			})
+			.block();
+
+		// 2. 응답 정제 (마크다운 제거)
+		String cleanedJson = cleanJson(rawResponse);
+		log.info("Gemini 정제된 응답: {}", cleanedJson);
+
+		// 3. JSON 변환
+		try {
+			Map<String, String> m = om.readValue(cleanedJson, new TypeReference<>() {});
+			return new StoryboardStructuredResponse(
+				m.get("cutSummary"),
+				m.get("script"),
+				m.get("caption"),
+				m.get("time")
+			);
+		} catch (Exception e) {
+			log.error("JSON 변환 실패. 원본: {}", rawResponse, e);
+			// 실패 시 Fallback: 원본 내용을 script에 저장
+			return new StoryboardStructuredResponse(
+				"구조화 실패",
+				aiMessageContent,
+				null,
+				null
+			);
+		}
+	}
+
+	// 마크다운 제거 메서드
+	private String cleanJson(String text) {
+		if (text == null || text.isBlank()) return "{}";
+		String cleaned = text.trim();
+		if (cleaned.startsWith("```json")) {
+			cleaned = cleaned.substring(7);
+		} else if (cleaned.startsWith("```")) {
+			cleaned = cleaned.substring(3);
+		}
+		if (cleaned.endsWith("```")) {
+			cleaned = cleaned.substring(0, cleaned.length() - 3);
+		}
+		return cleaned.trim();
+	}
+}

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/mapper/ChatMessageMapper.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/mapper/ChatMessageMapper.java
@@ -1,0 +1,26 @@
+package tave.crezipsa.crezipsa.infrastructure.chat.mapper;
+
+import tave.crezipsa.crezipsa.domain.chat.entity.ChatMessage;
+import tave.crezipsa.crezipsa.infrastructure.chat.entity.ChatMessageJpaEntity;
+
+public class ChatMessageMapper {
+
+	public static ChatMessage toDomain(ChatMessageJpaEntity e) {
+		return ChatMessage.builder()
+			.id(e.getMessageId())
+			.chatRoomId(e.getChatRoomId())
+			.senderType(ChatMessage.SenderType.valueOf(e.getSenderType().name()))
+			.content(e.getContent())
+			.build();
+	}
+
+	public static ChatMessageJpaEntity toJpa(ChatMessage d) {
+		return ChatMessageJpaEntity.builder()
+			.messageId(d.getId())
+			.chatRoomId(d.getChatRoomId())
+			.senderType(ChatMessageJpaEntity.SenderType.valueOf(d.getSenderType().name()))
+			.content(d.getContent())
+			.build();
+	}
+
+}

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/mapper/ChatRoomMapper.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/mapper/ChatRoomMapper.java
@@ -1,0 +1,23 @@
+package tave.crezipsa.crezipsa.infrastructure.chat.mapper;
+
+import tave.crezipsa.crezipsa.domain.chat.entity.ChatRoom;
+import tave.crezipsa.crezipsa.infrastructure.chat.entity.ChatRoomJpaEntity;
+
+public class ChatRoomMapper {
+
+	public static ChatRoom toDomain(ChatRoomJpaEntity e) {
+		return ChatRoom.builder()
+			.id(e.getChatRoomId())
+			.userId(e.getUserId())
+			.title(e.getChatTitle())
+			.build();
+	}
+
+	public static ChatRoomJpaEntity toJpa(ChatRoom d) {
+		return ChatRoomJpaEntity.builder()
+			.chatRoomId(d.getId())
+			.userId(d.getUserId())
+			.chatTitle(d.getTitle())
+			.build();
+	}
+}

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatMessageJpaRepository.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatMessageJpaRepository.java
@@ -1,0 +1,12 @@
+package tave.crezipsa.crezipsa.infrastructure.chat.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import tave.crezipsa.crezipsa.domain.chat.entity.ChatMessage;
+import tave.crezipsa.crezipsa.infrastructure.chat.entity.ChatMessageJpaEntity;
+
+public interface ChatMessageJpaRepository extends JpaRepository<ChatMessageJpaEntity, Long> {
+	List<ChatMessageJpaEntity> findByChatRoomId(Long chatRoomId);
+}

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatMessageRepositoryImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatMessageRepositoryImpl.java
@@ -1,0 +1,39 @@
+package tave.crezipsa.crezipsa.infrastructure.chat.repository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import tave.crezipsa.crezipsa.domain.chat.entity.ChatMessage;
+import tave.crezipsa.crezipsa.domain.chat.port.ChatMessageRepositoryPort;
+import tave.crezipsa.crezipsa.infrastructure.chat.mapper.ChatMessageMapper;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatMessageRepositoryImpl implements ChatMessageRepositoryPort {
+
+	private final ChatMessageJpaRepository chatMessageJpaRepository;
+
+	@Override
+	public ChatMessage save(ChatMessage message) {
+		return ChatMessageMapper.toDomain(
+			chatMessageJpaRepository.save(ChatMessageMapper.toJpa(message))
+		);
+	}
+
+	@Override
+	public List<ChatMessage> findByChatRoomId(Long chatRoomId) {
+		return chatMessageJpaRepository.findByChatRoomId(chatRoomId).stream()
+			.map(ChatMessageMapper::toDomain)
+			.collect(Collectors.toList());
+	}
+
+	@Override
+	public ChatMessage findById(Long messageId) {
+		return chatMessageJpaRepository.findById(messageId)
+			.map(ChatMessageMapper::toDomain)
+			.orElse(null);
+	}
+}

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatRoomJpaRepository.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatRoomJpaRepository.java
@@ -1,0 +1,9 @@
+package tave.crezipsa.crezipsa.infrastructure.chat.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import tave.crezipsa.crezipsa.infrastructure.chat.entity.ChatRoomJpaEntity;
+
+public interface ChatRoomJpaRepository extends JpaRepository<ChatRoomJpaEntity, Long> {
+
+}

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatRoomRepositoryImpl.java
@@ -1,0 +1,30 @@
+package tave.crezipsa.crezipsa.infrastructure.chat.repository;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import tave.crezipsa.crezipsa.domain.chat.entity.ChatRoom;
+import tave.crezipsa.crezipsa.domain.chat.port.ChatRoomRepositoryPort;
+import tave.crezipsa.crezipsa.infrastructure.chat.mapper.ChatRoomMapper;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatRoomRepositoryImpl implements ChatRoomRepositoryPort {
+
+	private final ChatRoomJpaRepository chatRoomJpaRepository;
+
+	@Override
+	public ChatRoom save(ChatRoom chatRoom) {
+		return ChatRoomMapper.toDomain(
+			chatRoomJpaRepository.save(ChatRoomMapper.toJpa(chatRoom))
+		);
+	}
+
+	@Override
+	public Optional<ChatRoom> findById(Long chatRoomId) {
+		return chatRoomJpaRepository.findById(chatRoomId)
+			.map(ChatRoomMapper::toDomain);
+	}
+}

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/storyboard/entity/StoryboardJpaEntity.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/storyboard/entity/StoryboardJpaEntity.java
@@ -1,0 +1,45 @@
+package tave.crezipsa.crezipsa.infrastructure.storyboard.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "story_board")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class StoryboardJpaEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long storyBoardId;
+
+	private Long userId;
+
+	private String storyboardTitle;
+
+	@Column(columnDefinition = "TEXT")
+	private String cutSummary;
+
+	@Column(columnDefinition = "TEXT")
+	private String script;
+
+	@Column(columnDefinition = "TEXT")
+	private String caption;
+
+	private String time;
+
+	private LocalDateTime createdAt;
+}

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/storyboard/mapper/StoryboardMapper.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/storyboard/mapper/StoryboardMapper.java
@@ -1,0 +1,34 @@
+package tave.crezipsa.crezipsa.infrastructure.storyboard.mapper;
+
+import tave.crezipsa.crezipsa.domain.storyboard.entity.Storyboard;
+import tave.crezipsa.crezipsa.infrastructure.storyboard.entity.StoryboardJpaEntity;
+
+public class StoryboardMapper {
+
+	public static Storyboard toDomain(StoryboardJpaEntity e) {
+		return Storyboard.builder()
+			.id(e.getStoryBoardId())
+			.userId(e.getUserId())
+			.title(e.getStoryboardTitle())
+			.cutSummary(e.getCutSummary())
+			.script(e.getScript())
+			.caption(e.getCaption())
+			.time(e.getTime())
+			.createdAt(e.getCreatedAt())
+			.build();
+	}
+
+	public static StoryboardJpaEntity toJpa(Storyboard d) {
+		return StoryboardJpaEntity.builder()
+			.storyBoardId(d.getId())
+			.userId(d.getUserId())
+			.storyboardTitle(d.getTitle())
+			.cutSummary(d.getCutSummary())
+			.script(d.getScript())
+			.caption(d.getCaption())
+			.time(d.getTime())
+			.createdAt(d.getCreatedAt())
+			.build();
+	}
+
+}

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/storyboard/repository/StoryboardJpaRepository.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/storyboard/repository/StoryboardJpaRepository.java
@@ -1,0 +1,12 @@
+package tave.crezipsa.crezipsa.infrastructure.storyboard.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import tave.crezipsa.crezipsa.infrastructure.storyboard.entity.StoryboardJpaEntity;
+
+public interface StoryboardJpaRepository extends JpaRepository<StoryboardJpaEntity, Long> {
+	List<StoryboardJpaEntity> findByUserId(Long userId);
+
+}

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/storyboard/repository/StoryboardRepositoryImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/storyboard/repository/StoryboardRepositoryImpl.java
@@ -1,0 +1,44 @@
+package tave.crezipsa.crezipsa.infrastructure.storyboard.repository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import tave.crezipsa.crezipsa.domain.storyboard.entity.Storyboard;
+import tave.crezipsa.crezipsa.domain.storyboard.port.StoryboardRepositoryPort;
+import tave.crezipsa.crezipsa.infrastructure.storyboard.mapper.StoryboardMapper;
+
+@Repository
+@RequiredArgsConstructor
+public class StoryboardRepositoryImpl implements StoryboardRepositoryPort {
+
+	private final StoryboardJpaRepository storyboardJpaRepository;
+
+	@Override
+	public Storyboard save(Storyboard storyboard) {
+		return StoryboardMapper.toDomain(
+			storyboardJpaRepository.save(StoryboardMapper.toJpa(storyboard))
+		);
+	}
+
+	@Override
+	public List<Storyboard> findByUserId(Long userId) {
+		return storyboardJpaRepository.findByUserId(userId).stream()
+			.map(StoryboardMapper::toDomain)
+			.collect(Collectors.toList());
+	}
+
+	@Override
+	public Storyboard findById(Long storyboardId) {
+		return storyboardJpaRepository.findById(storyboardId)
+			.map(StoryboardMapper::toDomain)
+			.orElse(null);
+	}
+
+	@Override
+	public void deleteById(Long storyboardId) {
+		storyboardJpaRepository.deleteById(storyboardId);
+	}
+}

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/trend/TrendAdapter.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/trend/TrendAdapter.java
@@ -1,0 +1,45 @@
+package tave.crezipsa.crezipsa.infrastructure.trend;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.PlatformTransactionManager;
+import tave.crezipsa.crezipsa.application.trend.port.TrendQueryPort;
+import tave.crezipsa.crezipsa.domain.user.enums.Platform;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class TrendAdapter implements TrendQueryPort {
+
+    private final @Qualifier("analyticsJdbc") NamedParameterJdbcTemplate jdbc;
+
+    @Override
+    public List<TrendRow> findTopKeywordsByPlatform(String platform) {
+
+        String sql = """
+            SELECT id, `rank` AS keyword_rank, keyword, platform
+            FROM analytics_top_keywords
+            WHERE platform = :platform
+            ORDER BY keyword_rank ASC
+        """;
+
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("platform", platform);
+
+        List<TrendRow> rows = jdbc.query(sql, params, (rs, rowNum) -> new TrendRow(
+                rs.getLong("id"),
+                rs.getInt("keyword_rank"),
+                rs.getString("keyword"),
+                rs.getString("platform")
+        ));
+
+        System.out.println("MAPPED SIZE=" + rows.size());
+        System.out.println("MAPPED=" + rows);
+
+        return rows;
+    }
+}

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/trend/TrendAdapter.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/trend/TrendAdapter.java
@@ -37,9 +37,6 @@ public class TrendAdapter implements TrendQueryPort {
                 rs.getString("platform")
         ));
 
-        System.out.println("MAPPED SIZE=" + rows.size());
-        System.out.println("MAPPED=" + rows);
-
         return rows;
     }
 }

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/trend/TrendRow.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/trend/TrendRow.java
@@ -1,0 +1,11 @@
+package tave.crezipsa.crezipsa.infrastructure.trend;
+
+import tave.crezipsa.crezipsa.domain.user.enums.Platform;
+
+public record TrendRow(
+        Long id,
+        int rank,
+        String keyword,
+        String platform
+) {
+}

--- a/src/main/java/tave/crezipsa/crezipsa/presentation/ai/GeminiTestController.java
+++ b/src/main/java/tave/crezipsa/crezipsa/presentation/ai/GeminiTestController.java
@@ -1,0 +1,18 @@
+package tave.crezipsa.crezipsa.presentation.ai;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import tave.crezipsa.crezipsa.domain.storyboard.port.StoryboardGeneratorPort;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/test/gemini")
+public class GeminiTestController {
+
+	private final StoryboardGeneratorPort storyboardGeneratorPort;
+
+	@PostMapping
+	public String test(@RequestBody String prompt) {
+		return storyboardGeneratorPort.generate(prompt);
+	}
+}

--- a/src/main/java/tave/crezipsa/crezipsa/presentation/chat/ChatController.java
+++ b/src/main/java/tave/crezipsa/crezipsa/presentation/chat/ChatController.java
@@ -1,0 +1,57 @@
+package tave.crezipsa.crezipsa.presentation.chat;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import tave.crezipsa.crezipsa.application.chat.dto.request.ChatMessageRequest;
+import tave.crezipsa.crezipsa.application.chat.dto.response.GeminiChatResponse;
+import tave.crezipsa.crezipsa.application.chat.usecase.ChatUseCase;
+import tave.crezipsa.crezipsa.domain.user.entity.User;
+import tave.crezipsa.crezipsa.global.common.dto.GlobalResponseDto;
+
+@RestController
+@RequestMapping("/api/chats")
+@RequiredArgsConstructor
+public class ChatController {
+
+	private final ChatUseCase chatUseCase;
+
+	@PostMapping
+	public GlobalResponseDto<Long> createChatRoom(
+		@AuthenticationPrincipal User user,
+		@RequestParam(required = false) String title
+	) {
+		Long chatRoomId = chatUseCase.createChatRoom(
+			user.getUserId(),
+			title
+		);
+
+		return GlobalResponseDto.success(chatRoomId);
+	}
+
+	@PostMapping("/{chatRoomId}/messages")
+	public GlobalResponseDto<GeminiChatResponse> sendMessage(
+		@AuthenticationPrincipal User user,
+		@PathVariable Long chatRoomId,
+		@Validated @RequestBody ChatMessageRequest request
+	) {
+		GeminiChatResponse response =
+			chatUseCase.sendUserMessage(
+				chatRoomId,
+				user.getUserId(),
+				request.message()
+			);
+
+		return GlobalResponseDto.success(response);
+	}
+
+
+
+}

--- a/src/main/java/tave/crezipsa/crezipsa/presentation/storyboard/StoryboardController.java
+++ b/src/main/java/tave/crezipsa/crezipsa/presentation/storyboard/StoryboardController.java
@@ -1,0 +1,86 @@
+package tave.crezipsa.crezipsa.presentation.storyboard;
+
+import java.util.List;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import tave.crezipsa.crezipsa.application.storyboard.dto.request.SaveStoryboardRequest;
+import tave.crezipsa.crezipsa.application.storyboard.dto.request.UpdateStoryboardRequest;
+import tave.crezipsa.crezipsa.application.storyboard.dto.response.StoryboardStructuredResponse;
+import tave.crezipsa.crezipsa.application.storyboard.dto.response.StoryboardSummaryResponse;
+import tave.crezipsa.crezipsa.application.storyboard.usecase.StoryboardUsecase;
+import tave.crezipsa.crezipsa.domain.user.entity.User;
+import tave.crezipsa.crezipsa.global.common.dto.GlobalResponseDto;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/storyboard")
+public class StoryboardController {
+
+	private final StoryboardUsecase storyboardUsecase;
+
+	@PostMapping("/create")
+	public GlobalResponseDto<StoryboardStructuredResponse> create(
+		@AuthenticationPrincipal User user,
+		@Validated @RequestBody SaveStoryboardRequest request
+	) {
+		StoryboardStructuredResponse response =
+			storyboardUsecase.createFromChatMessage(
+				user.getUserId(),
+				request.chatMessageId(),
+				request.title()
+			);
+
+		return GlobalResponseDto.success(response);
+	}
+
+	@GetMapping("/{storyboardId}")
+	public GlobalResponseDto<StoryboardStructuredResponse> get(
+		@AuthenticationPrincipal User user,
+		@PathVariable Long storyboardId
+	) {
+		return GlobalResponseDto.success(
+			storyboardUsecase.get(user.getUserId(), storyboardId)
+		);
+	}
+
+	@GetMapping
+	public GlobalResponseDto<List<StoryboardSummaryResponse>> getMyList(
+		@AuthenticationPrincipal User user
+	) {
+		return GlobalResponseDto.success(
+			storyboardUsecase.getMyList(user.getUserId())
+		);
+	}
+
+	@PatchMapping("/{storyboardId}")
+	public GlobalResponseDto<StoryboardStructuredResponse> update(
+		@AuthenticationPrincipal User user,
+		@PathVariable Long storyboardId,
+		@Validated @RequestBody UpdateStoryboardRequest request
+	) {
+		return GlobalResponseDto.success(
+			storyboardUsecase.update(user.getUserId(), storyboardId, request)
+		);
+	}
+
+	@DeleteMapping("/{storyboardId}")
+	public GlobalResponseDto<Void> delete(
+		@AuthenticationPrincipal User user,
+		@PathVariable Long storyboardId
+	) {
+		storyboardUsecase.delete(user.getUserId(), storyboardId);
+		return GlobalResponseDto.success();
+	}
+
+}

--- a/src/main/java/tave/crezipsa/crezipsa/presentation/trend/controller/TrendController.java
+++ b/src/main/java/tave/crezipsa/crezipsa/presentation/trend/controller/TrendController.java
@@ -1,0 +1,29 @@
+package tave.crezipsa.crezipsa.presentation.trend.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import tave.crezipsa.crezipsa.application.trend.dto.response.TrendResponse;
+import tave.crezipsa.crezipsa.application.trend.usecase.TrendUsecase;
+import tave.crezipsa.crezipsa.domain.user.entity.User;
+import tave.crezipsa.crezipsa.domain.user.enums.Platform;
+import tave.crezipsa.crezipsa.global.common.dto.GlobalResponseDto;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/main")
+public class TrendController {
+
+    private final TrendUsecase trendUsecase;
+
+    @GetMapping
+    public GlobalResponseDto<List<TrendResponse>> getTrendList(@AuthenticationPrincipal User user,  @RequestParam String platform){
+
+        return GlobalResponseDto.success(trendUsecase.execute(platform));
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
- AWS RDS에서 관리하는 데이터 분석 DB(analytics DB) 와 연결하기 위한 설정을 추가했습니다.
- Main DB는 사용자 개별 정보를 관리하며, 트렌드 조회 시에는 별도의 Bean을 주입하여 analytics DB를 사용하도록 분리했습니다.
- 트렌드 순위 조회는 읽기 전용·단순 조회 성격이기 때문에 JPA 대신NamedParameterJdbcTemplate을 사용하여 조회 성능을 개선했습니다.

## 🔍 참고 사항
- 로컬 환경에서 테스트를 위해서는 아래 명령어로 SSH 터널링을 통해 RDS analytics DB에 접근할 수 있습니다.

<터미널>
 ssh -i [pem키] -N -L 3307:crejipsa-db.c3cecucw0apk.ap-northeast-2.rds.amazonaws.com:3306 ubuntu@3.37.238.177

이후 아래 명령어로 포트가 정상적으로 열려 있는지 확인할 수 있습니다.
 netstat -ano | findstr :3307

- platform은 요청 파라미터 및 JDBC 바인딩 안정성을 고려해 String으로 처리하고
  조회 결과 DTO에서 Platform enum으로 변환하여 전달합니다.

## 🖼️ 스크린샷
<img width="1180" height="782" alt="스크린샷 2025-12-29 041950" src="https://github.com/user-attachments/assets/f38dc295-114b-4784-b477-4d53976803b0" />

## 🔗 관련 이슈
#26 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인