### PR TITLE
[Feat] #34 채팅방 리스트 및 상세 조회 구현

### DIFF
--- a/src/main/java/tave/crezipsa/crezipsa/application/chat/dto/request/ChangeChatRoomTitleRequest.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/chat/dto/request/ChangeChatRoomTitleRequest.java
@@ -1,0 +1,9 @@
+package tave.crezipsa.crezipsa.application.chat.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ChangeChatRoomTitleRequest(
+	@NotBlank(message = "채팅방 제목은 비어 있을 수 없습니다.")
+	String title
+) {
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/chat/dto/response/ChatDetailResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/chat/dto/response/ChatDetailResponse.java
@@ -10,4 +10,13 @@ public record ChatDetailResponse(
 	String content,
 	LocalDateTime createdAt
 ) {
+
+	public static ChatDetailResponse from(ChatMessage message) {
+		return new ChatDetailResponse(
+			message.getId(),
+			message.getSenderType(),
+			message.getContent(),
+			message.getCreatedAt()
+		);
+	}
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/chat/dto/response/ChatDetailResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/chat/dto/response/ChatDetailResponse.java
@@ -1,0 +1,13 @@
+package tave.crezipsa.crezipsa.application.chat.dto.response;
+
+import java.time.LocalDateTime;
+
+import tave.crezipsa.crezipsa.domain.chat.entity.ChatMessage;
+
+public record ChatDetailResponse(
+	Long messageId,
+	ChatMessage.SenderType senderType,
+	String content,
+	LocalDateTime createdAt
+) {
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/chat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/chat/dto/response/ChatMessageResponse.java
@@ -1,0 +1,10 @@
+package tave.crezipsa.crezipsa.application.chat.dto.response;
+
+import java.util.List;
+
+public record ChatMessageResponse(
+	Long chatRoomId,
+	String title,
+	List<ChatDetailResponse> messages
+) {
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/chat/dto/response/ChatRoomListResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/chat/dto/response/ChatRoomListResponse.java
@@ -1,0 +1,10 @@
+package tave.crezipsa.crezipsa.application.chat.dto.response;
+
+import java.time.LocalDateTime;
+
+public record ChatRoomListResponse(
+	Long chatRoomId,
+	String title,
+	LocalDateTime lastMessageAt
+) {
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/chat/usecase/ChatUseCase.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/chat/usecase/ChatUseCase.java
@@ -1,9 +1,17 @@
 package tave.crezipsa.crezipsa.application.chat.usecase;
 
+import java.util.List;
+
+import tave.crezipsa.crezipsa.application.chat.dto.response.ChatMessageResponse;
+import tave.crezipsa.crezipsa.application.chat.dto.response.ChatRoomListResponse;
 import tave.crezipsa.crezipsa.application.chat.dto.response.GeminiChatResponse;
 
 public interface ChatUseCase {
 
 	Long createChatRoom ( Long userId, String title);
 	GeminiChatResponse sendUserMessage(Long chatRoomId, Long userId, String message);
+	void changeChatRoomTitle(Long userId, Long chatRoomId, String title);
+	List<ChatRoomListResponse> getMyChatRooms(Long userId);
+	ChatMessageResponse getChatDetail(Long userId, Long chatRoomId);
+
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/chat/usecase/ChatUseCaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/chat/usecase/ChatUseCaseImpl.java
@@ -1,15 +1,22 @@
 package tave.crezipsa.crezipsa.application.chat.usecase;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
+import tave.crezipsa.crezipsa.application.chat.dto.response.ChatDetailResponse;
+import tave.crezipsa.crezipsa.application.chat.dto.response.ChatMessageResponse;
+import tave.crezipsa.crezipsa.application.chat.dto.response.ChatRoomListResponse;
 import tave.crezipsa.crezipsa.application.chat.dto.response.GeminiChatResponse;
 import tave.crezipsa.crezipsa.domain.chat.entity.ChatMessage;
 import tave.crezipsa.crezipsa.domain.chat.entity.ChatRoom;
 import tave.crezipsa.crezipsa.domain.chat.port.ChatMessageRepositoryPort;
 import tave.crezipsa.crezipsa.domain.chat.port.ChatRoomRepositoryPort;
 import tave.crezipsa.crezipsa.domain.storyboard.port.StoryboardGeneratorPort;
+import tave.crezipsa.crezipsa.global.exception.model.CommonException;
 
 @Service
 @RequiredArgsConstructor
@@ -41,10 +48,69 @@ public class ChatUseCaseImpl implements ChatUseCase {
 		return new GeminiChatResponse(aiReply);
 	}
 
+	@Override
+	public void changeChatRoomTitle(Long userId, Long chatRoomId, String title) {
+		ChatRoom room = getChatRoom(chatRoomId, userId);
+
+		chatRoomRepository.save(
+			room.changeTitle(resolveChatRoomTitle(title))
+		);
+	}
+
+	@Override
+	public List<ChatRoomListResponse> getMyChatRooms(Long userId) {
+		return chatRoomRepository.findByUserId(userId).stream()
+			.map(room -> new ChatRoomListResponse(
+				room.getId(),
+				room.getTitle(),
+				chatMessageRepository
+					.findLastMessageAt(room.getId())
+					.orElse(null)
+			))
+			.toList();
+	}
+
+	@Override
+	public ChatMessageResponse getChatDetail(Long userId, Long chatRoomId) {
+		ChatRoom room = getChatRoom(chatRoomId, userId);
+
+		var messages =
+			chatMessageRepository
+				.findByChatRoomIdOrderByCreatedAtAsc(chatRoomId)
+				.stream()
+				.map(ChatDetailResponse::from)
+				.toList();
+
+		return new ChatMessageResponse(
+			room.getId(),
+			room.getTitle(),
+			messages
+		);
+	}
+
 	private String resolveChatRooomTitle(String title) {
 		return (title == null || title.isBlank())
 			? "새 채팅"
 			: title;
 	}
 
+	private ChatRoom getChatRoom(Long chatRoomId, Long userId) {
+		return chatRoomRepository.findByIdAndUserId(chatRoomId, userId)
+			.orElseThrow(() ->
+				new CommonException(ErrorCode.CHAT_ROOM_NOT_FOUND)
+			);
+	}
+
+	private void validateChatRoomOwner(Long chatRoomId, Long userId) {
+		if (!chatRoomRepository
+			.findByIdAndUserId(chatRoomId, userId)
+			.isPresent()) {
+			throw new CommonException(ErrorCode.CHAT_ROOM_NOT_FOUND);
+		}
+	}
+	private String resolveChatRoomTitle(String title) {
+		return (title == null || title.isBlank())
+			? "새 채팅"
+			: title;
+	}
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/chat/usecase/ChatUseCaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/chat/usecase/ChatUseCaseImpl.java
@@ -50,8 +50,7 @@ public class ChatUseCaseImpl implements ChatUseCase {
 
 	@Override
 	public void changeChatRoomTitle(Long userId, Long chatRoomId, String title) {
-		ChatRoom room = getChatRoom(chatRoomId, userId);
-		room.changeTitle(title);
+		chatRoomRepository.changeTitle(chatRoomId, userId, title);
 	}
 
 	@Override

--- a/src/main/java/tave/crezipsa/crezipsa/application/chat/usecase/ChatUseCaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/chat/usecase/ChatUseCaseImpl.java
@@ -51,10 +51,7 @@ public class ChatUseCaseImpl implements ChatUseCase {
 	@Override
 	public void changeChatRoomTitle(Long userId, Long chatRoomId, String title) {
 		ChatRoom room = getChatRoom(chatRoomId, userId);
-
-		chatRoomRepository.save(
-			room.changeTitle(resolveChatRoomTitle(title))
-		);
+		room.changeTitle(title);
 	}
 
 	@Override

--- a/src/main/java/tave/crezipsa/crezipsa/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/chat/entity/ChatRoom.java
@@ -23,6 +23,15 @@ public class ChatRoom {
 			.createdAt(LocalDateTime.now())
 			.build();
 	}
+	public  ChatRoom changeTitle(String title) {
+		return ChatRoom.builder()
+			.id(this.id)
+			.userId(this.userId)
+			.title(title)
+			.createdAt(this.createdAt)
+			.build();
+	}
+
 }
 
 

--- a/src/main/java/tave/crezipsa/crezipsa/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/chat/entity/ChatRoom.java
@@ -24,9 +24,6 @@ public class ChatRoom {
 			.build();
 	}
 
-	public void changeTitle(String title) {
-		this.title = title;
-	}
 }
 
 

--- a/src/main/java/tave/crezipsa/crezipsa/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/chat/entity/ChatRoom.java
@@ -23,15 +23,10 @@ public class ChatRoom {
 			.createdAt(LocalDateTime.now())
 			.build();
 	}
-	public  ChatRoom changeTitle(String title) {
-		return ChatRoom.builder()
-			.id(this.id)
-			.userId(this.userId)
-			.title(title)
-			.createdAt(this.createdAt)
-			.build();
-	}
 
+	public void changeTitle(String title) {
+		this.title = title;
+	}
 }
 
 

--- a/src/main/java/tave/crezipsa/crezipsa/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/chat/entity/ChatRoom.java
@@ -13,7 +13,7 @@ public class ChatRoom {
 
 	private final Long id;
 	private final Long userId;
-	private final String title;
+	private String title;
 	private final LocalDateTime createdAt;
 
 	public static ChatRoom create(Long userId, String title) {

--- a/src/main/java/tave/crezipsa/crezipsa/domain/chat/port/ChatMessageRepositoryPort.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/chat/port/ChatMessageRepositoryPort.java
@@ -1,6 +1,8 @@
 package tave.crezipsa.crezipsa.domain.chat.port;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import tave.crezipsa.crezipsa.domain.chat.entity.ChatMessage;
 
@@ -9,5 +11,7 @@ public interface ChatMessageRepositoryPort {
 	ChatMessage save(ChatMessage message);
 	List<ChatMessage> findByChatRoomId(Long chatRoomId);
 	ChatMessage findById(Long id);
+	List<ChatMessage> findByChatRoomIdOrderByCreatedAtAsc(Long chatRoomId);
+	Optional<LocalDateTime> findLastMessageAt(Long chatRoomId);
 
 }

--- a/src/main/java/tave/crezipsa/crezipsa/domain/chat/port/ChatRoomRepositoryPort.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/chat/port/ChatRoomRepositoryPort.java
@@ -1,5 +1,6 @@
 package tave.crezipsa.crezipsa.domain.chat.port;
 
+import java.util.List;
 import java.util.Optional;
 
 import tave.crezipsa.crezipsa.domain.chat.entity.ChatRoom;
@@ -8,5 +9,7 @@ public interface ChatRoomRepositoryPort {
 
 	ChatRoom save(ChatRoom chatRoom);
 	Optional<ChatRoom> findById(Long chatRoomId);
+	List<ChatRoom> findByUserId(Long userId);
+	Optional<ChatRoom> findByIdAndUserId(Long chatRoomId, Long userId);
 
 }

--- a/src/main/java/tave/crezipsa/crezipsa/domain/chat/port/ChatRoomRepositoryPort.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/chat/port/ChatRoomRepositoryPort.java
@@ -11,5 +11,7 @@ public interface ChatRoomRepositoryPort {
 	Optional<ChatRoom> findById(Long chatRoomId);
 	List<ChatRoom> findByUserId(Long userId);
 	Optional<ChatRoom> findByIdAndUserId(Long chatRoomId, Long userId);
-
+	void changeTitle(Long chatRoomId, Long userId, String title);
 }
+
+

--- a/src/main/java/tave/crezipsa/crezipsa/global/exception/code/ErrorCode.java
+++ b/src/main/java/tave/crezipsa/crezipsa/global/exception/code/ErrorCode.java
@@ -47,6 +47,9 @@ public enum ErrorCode implements BaseErrorCode {
 	//스토리보드 관련
 	CHAT_NOT_FOUND(404, "C40405", "대화내역이 존재하지 않습니다"),
 
+	// 채팅 관련
+	CHAT_ROOM_NOT_FOUND(404, "CH40401", "채팅방을 찾을 수 없습니다."),
+	CHAT_ROOM_UNAUTHORIZED(403, "CH40301", "채팅방 접근 권한이 없습니다."),
 
 	// 서버 오류
 	INTERNAL_SERVER_ERROR(500, "S50001", "서버 내부 오류가 발생했습니다.");

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/entity/ChatMessageJpaEntity.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/entity/ChatMessageJpaEntity.java
@@ -1,5 +1,7 @@
 package tave.crezipsa.crezipsa.infrastructure.chat.entity;
 
+import java.time.LocalDateTime;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -34,6 +36,9 @@ public class ChatMessageJpaEntity {
 
 	@Column(columnDefinition = "TEXT")
 	private String content;
+
+	@Column(nullable = false)
+	private LocalDateTime createdAt;
 
 	public enum SenderType {
 		USER, AI

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/entity/ChatRoomJpaEntity.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/entity/ChatRoomJpaEntity.java
@@ -27,4 +27,7 @@ public class ChatRoomJpaEntity {
 
 	private String chatTitle;
 
+	public void changeTitle(String title) {
+		this.chatTitle = title;
+	}
 }

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/mapper/ChatMessageMapper.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/mapper/ChatMessageMapper.java
@@ -11,6 +11,7 @@ public class ChatMessageMapper {
 			.chatRoomId(e.getChatRoomId())
 			.senderType(ChatMessage.SenderType.valueOf(e.getSenderType().name()))
 			.content(e.getContent())
+			.createdAt(e.getCreatedAt())
 			.build();
 	}
 
@@ -20,6 +21,7 @@ public class ChatMessageMapper {
 			.chatRoomId(d.getChatRoomId())
 			.senderType(ChatMessageJpaEntity.SenderType.valueOf(d.getSenderType().name()))
 			.content(d.getContent())
+			.createdAt(d.getCreatedAt())
 			.build();
 	}
 

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatMessageJpaRepository.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatMessageJpaRepository.java
@@ -1,12 +1,25 @@
 package tave.crezipsa.crezipsa.infrastructure.chat.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import tave.crezipsa.crezipsa.domain.chat.entity.ChatMessage;
 import tave.crezipsa.crezipsa.infrastructure.chat.entity.ChatMessageJpaEntity;
 
 public interface ChatMessageJpaRepository extends JpaRepository<ChatMessageJpaEntity, Long> {
 	List<ChatMessageJpaEntity> findByChatRoomId(Long chatRoomId);
+
+	List<ChatMessageJpaEntity>
+	findByChatRoomIdOrderByCreatedAtAsc(Long chatRoomId);
+
+	@Query("""
+		select max(m.createdAt)
+		from ChatMessageJpaEntity m
+		where m.chatRoomId = :chatRoomId
+	""")
+	Optional<LocalDateTime> findLastMessageAt(Long chatRoomId);
 }

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatMessageRepositoryImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatMessageRepositoryImpl.java
@@ -1,6 +1,8 @@
 package tave.crezipsa.crezipsa.infrastructure.chat.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Repository;
@@ -35,5 +37,19 @@ public class ChatMessageRepositoryImpl implements ChatMessageRepositoryPort {
 		return chatMessageJpaRepository.findById(messageId)
 			.map(ChatMessageMapper::toDomain)
 			.orElse(null);
+	}
+
+	@Override
+	public List<ChatMessage> findByChatRoomIdOrderByCreatedAtAsc(Long chatRoomId) {
+		return chatMessageJpaRepository
+			.findByChatRoomIdOrderByCreatedAtAsc(chatRoomId)
+			.stream()
+			.map(ChatMessageMapper::toDomain)
+			.toList();
+	}
+
+	@Override
+	public Optional<LocalDateTime> findLastMessageAt(Long chatRoomId) {
+		return chatMessageJpaRepository.findLastMessageAt(chatRoomId);
 	}
 }

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatRoomJpaRepository.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatRoomJpaRepository.java
@@ -10,5 +10,5 @@ import tave.crezipsa.crezipsa.infrastructure.chat.entity.ChatRoomJpaEntity;
 public interface ChatRoomJpaRepository extends JpaRepository<ChatRoomJpaEntity, Long> {
 
 	List<ChatRoomJpaEntity> findByUserId(Long userId);
-	Optional<ChatRoomJpaEntity> findByIdAndUserId(Long id, Long userId);
+	Optional<ChatRoomJpaEntity> findByChatRoomIdAndUserId(Long chatRoomId, Long userId);
 }

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatRoomJpaRepository.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatRoomJpaRepository.java
@@ -1,9 +1,14 @@
 package tave.crezipsa.crezipsa.infrastructure.chat.repository;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import tave.crezipsa.crezipsa.infrastructure.chat.entity.ChatRoomJpaEntity;
 
 public interface ChatRoomJpaRepository extends JpaRepository<ChatRoomJpaEntity, Long> {
 
+	List<ChatRoomJpaEntity> findByUserId(Long userId);
+	Optional<ChatRoomJpaEntity> findByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatRoomRepositoryImpl.java
@@ -1,5 +1,6 @@
 package tave.crezipsa.crezipsa.infrastructure.chat.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
@@ -25,6 +26,20 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryPort {
 	@Override
 	public Optional<ChatRoom> findById(Long chatRoomId) {
 		return chatRoomJpaRepository.findById(chatRoomId)
+			.map(ChatRoomMapper::toDomain);
+	}
+
+	@Override
+	public List<ChatRoom> findByUserId(Long userId) {
+		return chatRoomJpaRepository.findByUserId(userId).stream()
+			.map(ChatRoomMapper::toDomain)
+			.toList();
+	}
+
+	@Override
+	public Optional<ChatRoom> findByIdAndUserId(Long chatRoomId, Long userId) {
+		return chatRoomJpaRepository
+			.findByIdAndUserId(chatRoomId, userId)
 			.map(ChatRoomMapper::toDomain);
 	}
 }

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatRoomRepositoryImpl.java
@@ -39,7 +39,7 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryPort {
 	@Override
 	public Optional<ChatRoom> findByIdAndUserId(Long chatRoomId, Long userId) {
 		return chatRoomJpaRepository
-			.findByIdAndUserId(chatRoomId, userId)
+			.findByChatRoomIdAndUserId(chatRoomId, userId)
 			.map(ChatRoomMapper::toDomain);
 	}
 }

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatRoomRepositoryImpl.java
@@ -8,6 +8,9 @@ import org.springframework.stereotype.Repository;
 import lombok.RequiredArgsConstructor;
 import tave.crezipsa.crezipsa.domain.chat.entity.ChatRoom;
 import tave.crezipsa.crezipsa.domain.chat.port.ChatRoomRepositoryPort;
+import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
+import tave.crezipsa.crezipsa.global.exception.model.CommonException;
+import tave.crezipsa.crezipsa.infrastructure.chat.entity.ChatRoomJpaEntity;
 import tave.crezipsa.crezipsa.infrastructure.chat.mapper.ChatRoomMapper;
 
 @Repository
@@ -41,5 +44,14 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryPort {
 		return chatRoomJpaRepository
 			.findByChatRoomIdAndUserId(chatRoomId, userId)
 			.map(ChatRoomMapper::toDomain);
+	}
+
+	@Override
+	public void changeTitle(Long chatRoomId, Long userId, String title) {
+		ChatRoomJpaEntity entity = chatRoomJpaRepository
+			.findByChatRoomIdAndUserId(chatRoomId,userId)
+			.orElseThrow(() -> new CommonException(ErrorCode.CHAT_ROOM_NOT_FOUND));
+
+		entity.changeTitle(title);
 	}
 }

--- a/src/main/java/tave/crezipsa/crezipsa/presentation/chat/ChatController.java
+++ b/src/main/java/tave/crezipsa/crezipsa/presentation/chat/ChatController.java
@@ -1,7 +1,11 @@
 package tave.crezipsa.crezipsa.presentation.chat;
 
+import java.util.List;
+
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -10,7 +14,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import lombok.RequiredArgsConstructor;
+import tave.crezipsa.crezipsa.application.chat.dto.request.ChangeChatRoomTitleRequest;
 import tave.crezipsa.crezipsa.application.chat.dto.request.ChatMessageRequest;
+import tave.crezipsa.crezipsa.application.chat.dto.response.ChatMessageResponse;
+import tave.crezipsa.crezipsa.application.chat.dto.response.ChatRoomListResponse;
 import tave.crezipsa.crezipsa.application.chat.dto.response.GeminiChatResponse;
 import tave.crezipsa.crezipsa.application.chat.usecase.ChatUseCase;
 import tave.crezipsa.crezipsa.domain.user.entity.User;
@@ -51,6 +58,44 @@ public class ChatController {
 
 		return GlobalResponseDto.success(response);
 	}
+
+	@GetMapping
+	public GlobalResponseDto<List<ChatRoomListResponse>> getMyChatRooms(
+		@AuthenticationPrincipal User user
+	) {
+		return GlobalResponseDto.success(
+			chatUseCase.getMyChatRooms(user.getUserId())
+		);
+	}
+
+	@GetMapping("/{chatRoomId}")
+	public GlobalResponseDto<ChatMessageResponse> getChatDetail(
+		@AuthenticationPrincipal User user,
+		@PathVariable Long chatRoomId
+	) {
+		return GlobalResponseDto.success(
+			chatUseCase.getChatDetail(
+				user.getUserId(),
+				chatRoomId
+			)
+		);
+	}
+
+	@PatchMapping("/{chatRoomId}/title")
+	public GlobalResponseDto<Void> changeChatRoomTitle(
+		@AuthenticationPrincipal User user,
+		@PathVariable Long chatRoomId,
+		@Validated @RequestBody ChangeChatRoomTitleRequest request
+	) {
+		chatUseCase.changeChatRoomTitle(
+			user.getUserId(),
+			chatRoomId,
+			request.title()
+		);
+		return GlobalResponseDto.success();
+	}
+
+
 
 
 


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
요구사항에 포함된 , 채팅방 리스트 목록 조회, 채팅방 안의 채팅 메시지 조회 , 채팅방 제목 변경등의 API 를 추가 작업하였습니다 

-현재 (01/08) 기준 스토리보드 리팩토링 PR이 머지되지않아, 엔티티코드와 스키마 불일치로 인해 테스트가 불가능한데, 
PR작성 먼저해두고 , 머지되는대로 바로 테스트하겠습니다.

내부적으로 최신순 정렬을 먹이기 위해 ChatMessageJPAEntity에 createdAt 필드를 추가하였습니다.

## 🔍 참고 사항
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->


## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

채팅방 리스트 조회
<img width="672" height="494" alt="스크린샷 2026-01-10 오후 3 39 51" src="https://github.com/user-attachments/assets/d949d589-8d3d-4b81-a407-c393e9ba43f8" />

채팅방 제목 변경
<img width="605" height="445" alt="스크린샷 2026-01-10 오후 3 40 36" src="https://github.com/user-attachments/assets/142e6786-fa63-49bb-9733-f14eb942760e" />


채팅방 상세 채팅들 조회
<img width="664" height="534" alt="스크린샷 2026-01-10 오후 3 39 43" src="https://github.com/user-attachments/assets/3029aff0-4fba-44ee-8328-4e8f17e7228a" />

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인