### PR TITLE
[Feat] #36 스토리보드 채팅방 검색 api 구현

### DIFF
--- a/src/main/java/tave/crezipsa/crezipsa/application/search/dto/response/UnifiedSearchResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/search/dto/response/UnifiedSearchResponse.java
@@ -1,0 +1,22 @@
+package tave.crezipsa.crezipsa.application.search.dto.response;
+
+import java.util.List;
+
+public record UnifiedSearchResponse(
+	String keyword,
+	boolean empty,
+	List<SearchItemResponse> items
+) {
+
+	public record SearchItemResponse(
+		Long id,
+		String title,
+		SearchType type
+	){}
+
+	public enum SearchType {
+		STORYBOARD,
+		CHAT_ROOM
+	}
+
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/search/dto/response/UnifiedSearchResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/search/dto/response/UnifiedSearchResponse.java
@@ -12,11 +12,11 @@ public record UnifiedSearchResponse(
 		Long id,
 		String title,
 		SearchType type
-	){}
+	) {
 
-	public enum SearchType {
-		STORYBOARD,
-		CHAT_ROOM
+		public enum SearchType {
+			STORYBOARD,
+			CHAT_ROOM
+		}
 	}
-
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/search/mapper/UnifiedSearchResponseMapper.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/search/mapper/UnifiedSearchResponseMapper.java
@@ -1,0 +1,42 @@
+package tave.crezipsa.crezipsa.application.search.mapper;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.springframework.stereotype.Component;
+
+import tave.crezipsa.crezipsa.application.search.dto.response.UnifiedSearchResponse;
+import tave.crezipsa.crezipsa.domain.chat.entity.ChatRoom;
+import tave.crezipsa.crezipsa.domain.storyboard.entity.Storyboard;
+
+@Component
+public class UnifiedSearchResponseMapper {
+
+	public List<UnifiedSearchResponse.SearchItemResponse> toItems(
+		List<Storyboard> storyboards,
+		List<ChatRoom> chatRooms
+	) {
+		return Stream.concat(
+			storyboards.stream().map(this::toStoryboardItem),
+			chatRooms.stream().map(this::toChatRoomItem)
+		)
+			.toList();
+	}
+
+	private UnifiedSearchResponse.SearchItemResponse toStoryboardItem(Storyboard storyboard) {
+		return new UnifiedSearchResponse.SearchItemResponse(
+			storyboard.getId(),
+			storyboard.getTitle(),
+			UnifiedSearchResponse.SearchItemResponse.SearchType.STORYBOARD
+		);
+	}
+
+	private UnifiedSearchResponse.SearchItemResponse toChatRoomItem(ChatRoom chatRoom) {
+		return new UnifiedSearchResponse.SearchItemResponse(
+			chatRoom.getId(),
+			chatRoom.getTitle(),
+			UnifiedSearchResponse.SearchItemResponse.SearchType.CHAT_ROOM
+		);
+	}
+
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/search/usecase/SearchUsecase.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/search/usecase/SearchUsecase.java
@@ -1,0 +1,7 @@
+package tave.crezipsa.crezipsa.application.search.usecase;
+
+import tave.crezipsa.crezipsa.application.search.dto.response.UnifiedSearchResponse;
+
+public interface SearchUsecase {
+	UnifiedSearchResponse search(Long userId, String keyword);
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/search/usecase/SearchUsecaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/search/usecase/SearchUsecaseImpl.java
@@ -10,6 +10,8 @@ import tave.crezipsa.crezipsa.application.search.dto.response.UnifiedSearchRespo
 import tave.crezipsa.crezipsa.application.search.mapper.UnifiedSearchResponseMapper;
 import tave.crezipsa.crezipsa.domain.chat.port.ChatRoomRepositoryPort;
 import tave.crezipsa.crezipsa.domain.storyboard.port.StoryboardRepositoryPort;
+import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
+import tave.crezipsa.crezipsa.global.exception.model.CommonException;
 
 @Service
 @RequiredArgsConstructor
@@ -25,7 +27,7 @@ public class SearchUsecaseImpl implements SearchUsecase {
 		String q = normalize(keyword);
 
 		if (q.isBlank()) {
-			return new UnifiedSearchResponse(q, true, List.of());
+			throw new CommonException(ErrorCode.SEARCH_KEYWORD_REQUIRED);
 		}
 
 		var storyboards = storyboardRepository.searchByTitle(userId, q);

--- a/src/main/java/tave/crezipsa/crezipsa/application/search/usecase/SearchUsecaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/search/usecase/SearchUsecaseImpl.java
@@ -24,11 +24,11 @@ public class SearchUsecaseImpl implements SearchUsecase {
 
 	@Override
 	public UnifiedSearchResponse search(Long userId, String keyword) {
-		String q = normalize(keyword);
-
-		if (q.isBlank()) {
+		if (keyword == null || keyword.isBlank()) {
 			throw new CommonException(ErrorCode.SEARCH_KEYWORD_REQUIRED);
 		}
+
+		String q = keyword.trim();
 
 		var storyboards = storyboardRepository.searchByTitle(userId, q);
 		var chatRooms = chatRoomRepository.searchByTitle(userId, q);
@@ -38,7 +38,5 @@ public class SearchUsecaseImpl implements SearchUsecase {
 		return new UnifiedSearchResponse(q, items.isEmpty(), items);
 	}
 
-	private String normalize(String keyword) {
-		return keyword == null ? "" : keyword.trim();
-	}
+
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/search/usecase/SearchUsecaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/search/usecase/SearchUsecaseImpl.java
@@ -1,0 +1,42 @@
+package tave.crezipsa.crezipsa.application.search.usecase;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import tave.crezipsa.crezipsa.application.search.dto.response.UnifiedSearchResponse;
+import tave.crezipsa.crezipsa.application.search.mapper.UnifiedSearchResponseMapper;
+import tave.crezipsa.crezipsa.domain.chat.port.ChatRoomRepositoryPort;
+import tave.crezipsa.crezipsa.domain.storyboard.port.StoryboardRepositoryPort;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SearchUsecaseImpl implements SearchUsecase {
+
+	private final StoryboardRepositoryPort storyboardRepository;
+	private final ChatRoomRepositoryPort chatRoomRepository;
+	private final UnifiedSearchResponseMapper mapper;
+
+	@Override
+	public UnifiedSearchResponse search(Long userId, String keyword) {
+		String q = normalize(keyword);
+
+		if (q.isBlank()) {
+			return new UnifiedSearchResponse(q, true, List.of());
+		}
+
+		var storyboards = storyboardRepository.searchByTitle(userId, q);
+		var chatRooms = chatRoomRepository.searchByTitle(userId, q);
+
+		var items = mapper.toItems(storyboards, chatRooms);
+
+		return new UnifiedSearchResponse(q, items.isEmpty(), items);
+	}
+
+	private String normalize(String keyword) {
+		return keyword == null ? "" : keyword.trim();
+	}
+}

--- a/src/main/java/tave/crezipsa/crezipsa/domain/chat/port/ChatRoomRepositoryPort.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/chat/port/ChatRoomRepositoryPort.java
@@ -10,6 +10,7 @@ public interface ChatRoomRepositoryPort {
 	ChatRoom save(ChatRoom chatRoom);
 	Optional<ChatRoom> findById(Long chatRoomId);
 	List<ChatRoom> findByUserId(Long userId);
+	List<ChatRoom> searchByTitle(Long userId, String keyword);
 	Optional<ChatRoom> findByIdAndUserId(Long chatRoomId, Long userId);
 	void changeTitle(Long chatRoomId, Long userId, String title);
 }

--- a/src/main/java/tave/crezipsa/crezipsa/domain/storyboard/port/StoryboardRepositoryPort.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/storyboard/port/StoryboardRepositoryPort.java
@@ -8,6 +8,7 @@ public interface StoryboardRepositoryPort {
 
 	Storyboard save(Storyboard storyboard);
 	List<Storyboard> findByUserId(Long userId);
+	List<Storyboard> searchByTitle(Long userId, String keyword);
 	Storyboard findById(Long storyboardId);
 	void deleteById(Long storyboardId);
 

--- a/src/main/java/tave/crezipsa/crezipsa/global/exception/code/ErrorCode.java
+++ b/src/main/java/tave/crezipsa/crezipsa/global/exception/code/ErrorCode.java
@@ -51,6 +51,11 @@ public enum ErrorCode implements BaseErrorCode {
 	CHAT_ROOM_NOT_FOUND(404, "CH40401", "채팅방을 찾을 수 없습니다."),
 	CHAT_ROOM_UNAUTHORIZED(403, "CH40301", "채팅방 접근 권한이 없습니다."),
 
+	// 검색 관련
+	// 검색 관련
+	SEARCH_KEYWORD_REQUIRED(400, "SE40001", "검색어는 필수입니다."),
+
+
 	// 서버 오류
 	INTERNAL_SERVER_ERROR(500, "S50001", "서버 내부 오류가 발생했습니다.");
 

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatRoomJpaRepository.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatRoomJpaRepository.java
@@ -11,4 +11,5 @@ public interface ChatRoomJpaRepository extends JpaRepository<ChatRoomJpaEntity, 
 
 	List<ChatRoomJpaEntity> findByUserId(Long userId);
 	Optional<ChatRoomJpaEntity> findByChatRoomIdAndUserId(Long chatRoomId, Long userId);
+	List<ChatRoomJpaEntity> findByUserIdAndChatTitleContaining(Long userId, String keyword);
 }

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatRoomRepositoryImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatRoomRepositoryImpl.java
@@ -54,4 +54,13 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepositoryPort {
 
 		entity.changeTitle(title);
 	}
+
+	@Override
+	public List<ChatRoom> searchByTitle(Long userId, String keyword) {
+		return chatRoomJpaRepository
+			.findByUserIdAndChatTitleContaining(userId, keyword)
+			.stream()
+			.map(ChatRoomMapper::toDomain)
+			.toList();
+	}
 }

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/storyboard/repository/StoryboardJpaRepository.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/storyboard/repository/StoryboardJpaRepository.java
@@ -8,5 +8,6 @@ import tave.crezipsa.crezipsa.infrastructure.storyboard.entity.StoryboardJpaEnti
 
 public interface StoryboardJpaRepository extends JpaRepository<StoryboardJpaEntity, Long> {
 	List<StoryboardJpaEntity> findByUserId(Long userId);
+	List<StoryboardJpaEntity> findByUserIdAndStoryboardTitleContaining(Long userId, String keyword);
 
 }

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/storyboard/repository/StoryboardRepositoryImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/storyboard/repository/StoryboardRepositoryImpl.java
@@ -41,4 +41,13 @@ public class StoryboardRepositoryImpl implements StoryboardRepositoryPort {
 	public void deleteById(Long storyboardId) {
 		storyboardJpaRepository.deleteById(storyboardId);
 	}
+
+	@Override
+	public List<Storyboard> searchByTitle(Long userId, String keyword) {
+		return storyboardJpaRepository
+			.findByUserIdAndStoryboardTitleContaining(userId, keyword)
+			.stream()
+			.map(StoryboardMapper::toDomain)
+			.toList();
+	}
 }

--- a/src/main/java/tave/crezipsa/crezipsa/presentation/search/controller/SearchController.java
+++ b/src/main/java/tave/crezipsa/crezipsa/presentation/search/controller/SearchController.java
@@ -1,0 +1,31 @@
+package tave.crezipsa.crezipsa.presentation.search.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import tave.crezipsa.crezipsa.application.search.dto.response.UnifiedSearchResponse;
+import tave.crezipsa.crezipsa.application.search.usecase.SearchUsecase;
+import tave.crezipsa.crezipsa.domain.user.entity.User;
+import tave.crezipsa.crezipsa.global.common.dto.GlobalResponseDto;
+
+@RestController
+@RequestMapping("/api/search")
+@RequiredArgsConstructor
+public class SearchController {
+
+	private final SearchUsecase searchUsecase;
+
+	@GetMapping
+	public GlobalResponseDto<UnifiedSearchResponse> search(
+		@AuthenticationPrincipal User user,
+		@RequestParam String keyword
+	) {
+		return GlobalResponseDto.success(
+			searchUsecase.search(user.getUserId(), keyword)
+		);
+	}
+}


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
기획 요구사항에 맞게끔 UI 사이드 탭을 눌렀을 때,  뜨는 검색 창에서 스토리보드 및 채팅방을 동시에 검색할 수 있는 기능을 구현하였습니다.
<img width="533" height="479" alt="스크린샷 2026-01-11 오후 3 29 53" src="https://github.com/user-attachments/assets/af5ce94d-7c6e-489b-9fb7-1bb29968f192" />

하나의 화면 안에 키워드를 넣어서 검색을 하면 그 키워드와 일치하는 스토리보드/채팅방이 조회됩니다.
스토리보드/채팅 방 각각은  독립된 도메인으로만 접근이 가능했기 때문에 통합 검색 구조를 위한 search 유스케이스/검색 전용 응답 DTO 및 mapper를 설계하였습니다.
검색 시, 키워드 입력은 필수이며 미입력시 "검색어는 필수입니다"라는 예외가 처리됩니다.
만약 검색결과가 없는 경우 empty 필드의 true, false 여부를 통해 프론트 측에서 검색결과가 없음을 확인합니다.

```
{
    "success": true,
    "status": 200,
    "message": "요청이 성공적으로 처리되었습니다.",
    "result": {
        "keyword": "두바이초콜릿",
        "empty": true,
        "items": []
    }
}
```



## 🔍 참고 사항
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->


## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->
- 검색결과가 있는 keyword로 검색했을 때
<img width="666" height="508" alt="스크린샷 2026-01-11 오후 3 16 16" src="https://github.com/user-attachments/assets/8ec4818d-0e03-4542-9d2e-4b132f1e8e12" />

-검색결과가 없는 키워드로 검색했을 때

<img width="663" height="423" alt="스크린샷 2026-01-11 오후 3 25 19" src="https://github.com/user-attachments/assets/d58f6902-0dba-4aae-be04-af4f1ff379eb" />

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [x] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인