### PR TITLE
feat/#39/앱방식로그인구현

### DIFF
--- a/src/main/java/tave/crezipsa/crezipsa/application/auth/usecase/KakaoLoginUsecase.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/auth/usecase/KakaoLoginUsecase.java
@@ -22,6 +22,37 @@ public class KakaoLoginUsecase {
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthRepository authRepository;
 
+    public LoginResponse loginForApp(String kakaoToken) {
+        KakaoUserInfo kakaoUserInfo = kakaoOAuthClient.getUserInfo(kakaoToken);
+
+        User user = userRepository.findByEmail(kakaoUserInfo.getEmail())
+                .orElse(null);
+
+        if (user == null) {
+            return LoginResponse.needsSignup(kakaoUserInfo);
+        }
+        if(user.isRole()) {
+            throw new CommonException(ErrorCode.USER_INVALID_ROLE);
+        }
+
+        // 이메일도 존재하고//새로운 유저가 아닐때 바로 토큰 발급
+        String jwt = jwtTokenProvider.generateAccessToken(user.getUserId());
+        String refreshToken = jwtTokenProvider.generateRefreshToken(user.getUserId());
+
+        Auth auth = authRepository.findByUserId(user.getUserId())
+                .orElseGet(() -> Auth.builder()
+                        .userId(user.getUserId())
+                        .providerUserId(String.valueOf(kakaoUserInfo.getId()))
+                        .build()
+                );
+
+        auth.updateTokens(kakaoToken, refreshToken);
+        authRepository.save(auth);
+
+        return LoginResponse.success(jwt, refreshToken, kakaoUserInfo);
+    }
+
+    //웹 방식 카카오 로그인
     public LoginResponse login(String code) {
 
         String kakaoToken = kakaoOAuthClient.getAccessToken(code);

--- a/src/main/java/tave/crezipsa/crezipsa/presentation/auth/controller/OAuthController.java
+++ b/src/main/java/tave/crezipsa/crezipsa/presentation/auth/controller/OAuthController.java
@@ -18,6 +18,13 @@ public class OAuthController {
     private final KakaoLoginUsecase kakaoLoginUsecase;
     private final AuthUsecase authUsecase;
 
+    @GetMapping("/kakaoLogin")
+    public GlobalResponseDto<LoginResponse> kakaoLoginForApp(@RequestParam String kakaoToken) {
+        LoginResponse response = kakaoLoginUsecase.loginForApp(kakaoToken);
+
+        return GlobalResponseDto.success(response);
+    }
+
     @GetMapping("/kakao")
     public GlobalResponseDto<LoginResponse> kakaoLogin(@RequestParam String code) {
         LoginResponse response = kakaoLoginUsecase.login(code);


### PR DESCRIPTION
## 📌 작업한 내용
기존 인가 코드(code) 기반 카카오 로그인 플로우(code → 카카오 인증/인가 → 사용자 정보 조회)는 유지하면서,
프론트에서 전달받은 카카오 accessToken 으로 사용자 정보를 조회해 로그인/회원가입을 처리하는 로직을 추가했습니다.
즉, 웹(코드 기반) / 앱(토큰 기반) 두 가지 로그인 방식을 모두 지원합니다.

## 🔍 참고 사항
- 토큰 기반 로그인(앱): @GetMapping("/kakaoLogin")
- 코드 기반 로그인(웹): @GetMapping("/kakao")

## 🖼️ 스크린샷
<img width="728" height="756" alt="image" src="https://github.com/user-attachments/assets/ffd7eed2-5e1a-45d5-8054-b44d0b7801d2" />

## 🔗 관련 이슈
#39 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [ ] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인