### PR TITLE
Feat/#45/사용자기반트렌드추천

### DIFF
--- a/src/main/java/tave/crezipsa/crezipsa/application/trend/dto/response/TrendDetailResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/trend/dto/response/TrendDetailResponse.java
@@ -10,10 +10,11 @@ import java.util.List;
 public record TrendDetailResponse(
         Long id,
         Platform platform,
+        String category,
         int overall_rank,
         int category_rank,
         String keyword,
-        int frequency,
+        double viralityScore,
         List<TrendUrlResponse> urls
 
 ) {
@@ -30,10 +31,11 @@ public record TrendDetailResponse(
         return new TrendDetailResponse(
                 trendDetailWithUrls.detailRow().id(),
                 Platform.valueOf(trendDetailWithUrls.detailRow().platform()),
+                trendDetailWithUrls.detailRow().category(),
                 trendDetailWithUrls.detailRow().overall_rank(),
                 trendDetailWithUrls.detailRow().category_rank(),
                 trendDetailWithUrls.detailRow().keyword(),
-                trendDetailWithUrls.detailRow().frequency(),
+                trendDetailWithUrls.detailRow().viralityScore(),
                 urls
         );
     }

--- a/src/main/java/tave/crezipsa/crezipsa/application/trend/dto/response/TrendResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/trend/dto/response/TrendResponse.java
@@ -4,7 +4,6 @@ import tave.crezipsa.crezipsa.domain.user.enums.Platform;
 import tave.crezipsa.crezipsa.infrastructure.trend.TrendRow;
 
 public record TrendResponse(
-
         Long id,
         String keyword,
         int rank,

--- a/src/main/java/tave/crezipsa/crezipsa/application/trend/dto/response/TrendResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/trend/dto/response/TrendResponse.java
@@ -3,7 +3,7 @@ package tave.crezipsa.crezipsa.application.trend.dto.response;
 import tave.crezipsa.crezipsa.domain.user.enums.Platform;
 import tave.crezipsa.crezipsa.infrastructure.trend.TrendRow;
 
-public record TrendListResponse(
+public record TrendResponse(
 
         Long id,
         String keyword,
@@ -11,10 +11,10 @@ public record TrendListResponse(
         Platform platform,
         String category
 ) {
-    public static TrendListResponse from(TrendRow row) {
+    public static TrendResponse from(TrendRow row) {
         Platform platform = row.platform() == null ? null : Platform.valueOf(row.platform());
 
-        return new TrendListResponse(
+        return new TrendResponse(
                 row.id(),
                 row.keyword(),
                 row.rank(),

--- a/src/main/java/tave/crezipsa/crezipsa/application/trend/dto/response/TrendSearchResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/trend/dto/response/TrendSearchResponse.java
@@ -5,12 +5,12 @@ import tave.crezipsa.crezipsa.infrastructure.trend.TrendWithUrls;
 import java.util.List;
 
 public record TrendSearchResponse(
-        List<TrendListResponse> trends,
+        List<TrendResponse> trends,
         List<TrendUrlResponse> videos
 ) {
     public static TrendSearchResponse from(TrendWithUrls result) {
         return new TrendSearchResponse(
-                result.rows().stream().map(TrendListResponse::from).toList(),
+                result.rows().stream().map(TrendResponse::from).toList(),
                 result.urls().stream().map(TrendUrlResponse::from).toList()
         );
     }

--- a/src/main/java/tave/crezipsa/crezipsa/application/trend/port/TrendQueryPort.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/trend/port/TrendQueryPort.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 public interface TrendQueryPort {
     List<TrendRow> findTopKeywordsByPlatformAndCategory(String platform, String category);
+    List<TrendRow> findTopKeywordsByCategory(List<String> categories);
     TrendDetailWithUrls findSelectedKeywordDetailBytrendId(long trendId);
     void saveTrend(long userId, TrendCommand trendCommand);
     TrendWithUrls findKeywordByKeyword(String keyword);

--- a/src/main/java/tave/crezipsa/crezipsa/application/trend/usecase/TrendUsecase.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/trend/usecase/TrendUsecase.java
@@ -1,19 +1,19 @@
 package tave.crezipsa.crezipsa.application.trend.usecase;
 
 import tave.crezipsa.crezipsa.application.trend.dto.response.TrendDetailResponse;
-import tave.crezipsa.crezipsa.application.trend.dto.response.TrendListResponse;
+import tave.crezipsa.crezipsa.application.trend.dto.response.TrendResponse;
 import tave.crezipsa.crezipsa.application.trend.dto.response.TrendSearchResponse;
 import tave.crezipsa.crezipsa.application.trend.dto.response.request.TrendRequest;
-import tave.crezipsa.crezipsa.infrastructure.trend.TrendWithUrls;
 
 import java.util.List;
 
 
 public interface TrendUsecase {
 
-    List<TrendListResponse> getTopTrends(String platform, String category);
+    List<TrendResponse> getTopTrends(String platform, String category);
     TrendDetailResponse getTrendDetail(long trendId);
     void saveTrend(long userId, TrendRequest request);
     TrendSearchResponse searchTrend(String keyword);
+    List<TrendResponse> trendRecommendByPlatform(String platform);
 
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/trend/usecase/TrendUsecase.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/trend/usecase/TrendUsecase.java
@@ -4,6 +4,7 @@ import tave.crezipsa.crezipsa.application.trend.dto.response.TrendDetailResponse
 import tave.crezipsa.crezipsa.application.trend.dto.response.TrendResponse;
 import tave.crezipsa.crezipsa.application.trend.dto.response.TrendSearchResponse;
 import tave.crezipsa.crezipsa.application.trend.dto.response.request.TrendRequest;
+import tave.crezipsa.crezipsa.domain.user.entity.User;
 
 import java.util.List;
 
@@ -14,6 +15,6 @@ public interface TrendUsecase {
     TrendDetailResponse getTrendDetail(long trendId);
     void saveTrend(long userId, TrendRequest request);
     TrendSearchResponse searchTrend(String keyword);
-    List<TrendResponse> trendRecommendByPlatform(String platform);
+    List<TrendResponse> recommendTrendsByInterests(long userId);
 
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/trend/usecase/TrendUsecaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/trend/usecase/TrendUsecaseImpl.java
@@ -4,13 +4,12 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import tave.crezipsa.crezipsa.application.trend.dto.response.TrendDetailResponse;
-import tave.crezipsa.crezipsa.application.trend.dto.response.TrendListResponse;
+import tave.crezipsa.crezipsa.application.trend.dto.response.TrendResponse;
 import tave.crezipsa.crezipsa.application.trend.dto.response.TrendSearchResponse;
 import tave.crezipsa.crezipsa.application.trend.dto.response.request.TrendRequest;
 import tave.crezipsa.crezipsa.application.trend.port.TrendQueryPort;
 import tave.crezipsa.crezipsa.infrastructure.trend.TrendDetailWithUrls;
 import tave.crezipsa.crezipsa.infrastructure.trend.TrendRow;
-import tave.crezipsa.crezipsa.infrastructure.trend.TrendWithUrls;
 
 import java.util.List;
 
@@ -22,11 +21,11 @@ public class TrendUsecaseImpl implements TrendUsecase {
     private final TrendQueryPort trendQueryPort;
 
     @Override
-    public List<TrendListResponse> getTopTrends(String platform, String category) {
+    public List<TrendResponse> getTopTrends(String platform, String category) {
 
         List<TrendRow> trendRowList = trendQueryPort.findTopKeywordsByPlatformAndCategory(platform, category);
         return trendRowList.stream()
-                .map(TrendListResponse::from)
+                .map(TrendResponse::from)
                 .toList();
     }
 
@@ -46,5 +45,7 @@ public class TrendUsecaseImpl implements TrendUsecase {
     public TrendSearchResponse searchTrend(String keyword) {
         return TrendSearchResponse.from(trendQueryPort.findKeywordByKeyword(keyword));
     }
+
+
 
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/trend/usecase/TrendUsecaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/trend/usecase/TrendUsecaseImpl.java
@@ -8,6 +8,10 @@ import tave.crezipsa.crezipsa.application.trend.dto.response.TrendResponse;
 import tave.crezipsa.crezipsa.application.trend.dto.response.TrendSearchResponse;
 import tave.crezipsa.crezipsa.application.trend.dto.response.request.TrendRequest;
 import tave.crezipsa.crezipsa.application.trend.port.TrendQueryPort;
+import tave.crezipsa.crezipsa.application.user.port.UserInterestPort;
+import tave.crezipsa.crezipsa.domain.user.entity.User;
+import tave.crezipsa.crezipsa.domain.user.entity.UserInterest;
+import tave.crezipsa.crezipsa.domain.user.repository.UserInterestRepository;
 import tave.crezipsa.crezipsa.infrastructure.trend.TrendDetailWithUrls;
 import tave.crezipsa.crezipsa.infrastructure.trend.TrendRow;
 
@@ -19,6 +23,7 @@ import java.util.List;
 public class TrendUsecaseImpl implements TrendUsecase {
 
     private final TrendQueryPort trendQueryPort;
+    private final UserInterestPort userInterestPort;
 
     @Override
     public List<TrendResponse> getTopTrends(String platform, String category) {
@@ -46,6 +51,14 @@ public class TrendUsecaseImpl implements TrendUsecase {
         return TrendSearchResponse.from(trendQueryPort.findKeywordByKeyword(keyword));
     }
 
+    @Override
+    public List<TrendResponse> recommendTrendsByInterests(long userId) {
+        List<String> userInterests = userInterestPort.getInterests(userId);
+        List<TrendRow> trendRowList = trendQueryPort.findTopKeywordsByCategory(userInterests);
 
+        return trendRowList.stream()
+                .map(TrendResponse::from)
+                .toList();
+    }
 
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/user/dto/request/UserSignUpRequest.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/user/dto/request/UserSignUpRequest.java
@@ -23,6 +23,8 @@ public record UserSignUpRequest(
         String activeTiktok,
         String activeInsta,
         Platform mainPlatform,
+
+        @NotEmpty(message = "하나 이상의 관심 분야 설정이 필요합니다.")
         List<String> userInterest
 ) {
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/user/port/UserInterestPort.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/user/port/UserInterestPort.java
@@ -1,0 +1,7 @@
+package tave.crezipsa.crezipsa.application.user.port;
+
+import java.util.List;
+
+public interface UserInterestPort {
+    List<String> getInterests(long userId);
+}

--- a/src/main/java/tave/crezipsa/crezipsa/domain/user/entity/User.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/user/entity/User.java
@@ -29,7 +29,7 @@ public class User {
                 .nickName(cmd.nickName())
                 .email(cmd.email())
                 .gender(cmd.gender())
-                .role(true)
+                .role(false)
                 .birth(cmd.birth())
                 .activeYoutube(cmd.activeYoutube())
                 .activeInsta(cmd.activeInsta())

--- a/src/main/java/tave/crezipsa/crezipsa/global/exception/code/ErrorCode.java
+++ b/src/main/java/tave/crezipsa/crezipsa/global/exception/code/ErrorCode.java
@@ -10,8 +10,9 @@ public enum ErrorCode implements BaseErrorCode {
 
 	//카테고리 관련
 	INVALD_INTEREST(404,"I40401", "존재하지 않은 사용자 관심 카테고리입니다."),
-	ALREADY_INTEREST(400,"I40001","이미 선택한 사용자 관심 카테고리입니다."),
-
+	ALREADY_INTEREST(400,"I40002","이미 선택한 사용자 관심 카테고리입니다."),
+	USER_INTEREST_NOT_SET (400,"I40003", "관심 카테고리가 설정되지 않았습니다."),
+	USER_INTEREST_NOT_FOUND(404,"I4004","사용자 관심 카테고리를 찾을 수 없습니다."),
 	// 인증 관련
 	MISSING_AUTH_HEADER(400, "A40101", "Authorization 헤더가 누락되었습니다."),
 	INVALID_TOKEN(401, "A40102", "토큰이 유효하지 않습니다."),
@@ -53,9 +54,7 @@ public enum ErrorCode implements BaseErrorCode {
 	CHAT_ROOM_UNAUTHORIZED(403, "CH40301", "채팅방 접근 권한이 없습니다."),
 
 	// 검색 관련
-	// 검색 관련
 	SEARCH_KEYWORD_REQUIRED(400, "SE40001", "검색어는 필수입니다."),
-
 
 	// 서버 오류
 	INTERNAL_SERVER_ERROR(500, "S50001", "서버 내부 오류가 발생했습니다.");

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/trend/TrendAdapter.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/trend/TrendAdapter.java
@@ -75,7 +75,7 @@ public class TrendAdapter implements TrendQueryPort {
     public TrendDetailWithUrls findSelectedKeywordDetailBytrendId(long trendId) {
 
         String keywordSql = """
-            SELECT id, overall_rank, category_rank, keyword, platform, category_name, keyword_frequency
+            SELECT id, overall_rank, category_rank, keyword, platform, category_name, virality_score
             FROM analytics_keyword_virality
             WHERE id = :id
         """;
@@ -88,10 +88,11 @@ public class TrendAdapter implements TrendQueryPort {
                 (rs, rowNum) -> new TrendDetailRow(
                         rs.getLong("id"),
                         rs.getString("platform"),
+                        rs.getString("category_name"),
                         rs.getInt("overall_rank"),
                         rs.getInt("category_rank"),
                         rs.getString("keyword"),
-                        rs.getInt("keyword_frequency")
+                        rs.getInt("virality_score")
                 )
         );
 

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/trend/TrendAdapter.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/trend/TrendAdapter.java
@@ -10,6 +10,7 @@ import tave.crezipsa.crezipsa.application.trend.port.TrendQueryPort;
 import tave.crezipsa.crezipsa.domain.trend.entity.command.TrendCommand;
 import tave.crezipsa.crezipsa.domain.user.enums.Platform;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Repository
@@ -69,6 +70,36 @@ public class TrendAdapter implements TrendQueryPort {
         }
 
         return rows;
+    }
+
+    @Override
+    public List<TrendRow> findTopKeywordsByCategory(List<String> categories) {
+
+        String sql = """
+        SELECT id, keyword,category_name
+        FROM analytics_keyword_virality
+        WHERE category_name = :category
+        ORDER BY category_rank ASC
+        LIMIT :limit
+    """;
+
+        List<TrendRow> result = new ArrayList<>();
+
+        for (String category : categories) {
+            MapSqlParameterSource params = new MapSqlParameterSource()
+                    .addValue("category", category)
+                    .addValue("limit", 10);
+
+            List<TrendRow> rows = analyticsJdbc.query(sql, params, (rs, rowNum) -> new TrendRow(
+                    rs.getLong("id"),
+                    rs.getString("keyword"),
+                    rs.getString("category_name")
+            ));
+
+            result.addAll(rows);
+        }
+
+        return result;
     }
 
     @Override

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/trend/TrendDetailRow.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/trend/TrendDetailRow.java
@@ -5,10 +5,11 @@ import java.util.List;
 public record TrendDetailRow(
             Long id,
             String platform,
+            String category,
             int overall_rank,
             int category_rank,
             String keyword,
-            int frequency
+            double viralityScore
     ) {
     }
 

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/user/adapter/UserInterestAdapter.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/user/adapter/UserInterestAdapter.java
@@ -1,0 +1,34 @@
+package tave.crezipsa.crezipsa.infrastructure.user.adapter;
+
+import lombok.Locked;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+import tave.crezipsa.crezipsa.application.user.port.UserInterestPort;
+import tave.crezipsa.crezipsa.domain.user.entity.UserInterest;
+import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
+import tave.crezipsa.crezipsa.global.exception.model.CommonException;
+import tave.crezipsa.crezipsa.infrastructure.user.repository.UserInterestJpaRepository;
+import tave.crezipsa.crezipsa.infrastructure.user.repository.UserJpaRepository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+@Transactional
+public class UserInterestAdapter implements UserInterestPort {
+    private final UserInterestJpaRepository userInterestJpaRepository;
+
+    @Override
+    public List<String> getInterests(long userId) {
+        List<UserInterest> interests = userInterestJpaRepository.findAllByUserId(userId);
+
+        if (interests.isEmpty()) {
+            throw new CommonException(ErrorCode.USER_INTEREST_NOT_SET);
+        }
+
+        return interests.stream()
+                .map(UserInterest::getCategory)
+                .toList();
+    }
+}

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/user/repository/UserInterestJpaRepository.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/user/repository/UserInterestJpaRepository.java
@@ -11,6 +11,5 @@ public interface UserInterestJpaRepository extends JpaRepository<UserInterest, L
     List<UserInterest> findAllByUserId(Long userId);
     UserInterest save(UserInterest userInterest);
     boolean existsByUserIdAndCategory(Long userId, String category);
-    Optional<UserInterest> findByUserIdAndCategory(Long userId, String category);
     void deleteByInterestId(Long interestId);
 }

--- a/src/main/java/tave/crezipsa/crezipsa/presentation/trend/controller/TrendController.java
+++ b/src/main/java/tave/crezipsa/crezipsa/presentation/trend/controller/TrendController.java
@@ -46,4 +46,8 @@ public class TrendController {
         return GlobalResponseDto.success(trendUsecase.getTopTrends(user.getMainPlatform().toString(), null));
     }
 
+    @GetMapping("recommendations/by-interests")
+    public GlobalResponseDto<List<TrendResponse>> recommendationsByInterests(@AuthenticationPrincipal User user){
+        return GlobalResponseDto.success(trendUsecase.recommendTrendsByInterests(user.getUserId()));
+    }
 }

--- a/src/main/java/tave/crezipsa/crezipsa/presentation/trend/controller/TrendController.java
+++ b/src/main/java/tave/crezipsa/crezipsa/presentation/trend/controller/TrendController.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import tave.crezipsa.crezipsa.application.trend.dto.response.TrendDetailResponse;
-import tave.crezipsa.crezipsa.application.trend.dto.response.TrendListResponse;
+import tave.crezipsa.crezipsa.application.trend.dto.response.TrendResponse;
 import tave.crezipsa.crezipsa.application.trend.dto.response.TrendSearchResponse;
 import tave.crezipsa.crezipsa.application.trend.dto.response.request.TrendRequest;
 import tave.crezipsa.crezipsa.application.trend.usecase.TrendUsecase;
@@ -20,9 +20,8 @@ public class TrendController {
 
     private final TrendUsecase trendUsecase;
 
-    //완료
     @GetMapping
-    public GlobalResponseDto<List<TrendListResponse>> getTrendList(@AuthenticationPrincipal User user, @RequestParam(defaultValue = "YOUTUBE") String platform, @RequestParam(required = false) String category){
+    public GlobalResponseDto<List<TrendResponse>> getTrendList(@AuthenticationPrincipal User user, @RequestParam(defaultValue = "YOUTUBE") String platform, @RequestParam(required = false) String category){
         return GlobalResponseDto.success(trendUsecase.getTopTrends(platform, category));
     }
 
@@ -40,6 +39,11 @@ public class TrendController {
     @GetMapping("/search/{trend}")
     public GlobalResponseDto<TrendSearchResponse> searchTrend(@AuthenticationPrincipal User user, @PathVariable String trend){
         return GlobalResponseDto.success(trendUsecase.searchTrend(trend));
+    }
+
+    @GetMapping("recommendations/by-platform")
+    public GlobalResponseDto<List<TrendResponse>> recommendationsByPlatform(@AuthenticationPrincipal User user){
+        return GlobalResponseDto.success(trendUsecase.getTopTrends(user.getMainPlatform().toString(), null));
     }
 
 }


### PR DESCRIPTION
## 📌 작업한 내용
- 사용자가 지정한 메인 플랫폼/관심 분야 기반 트렌드 추천 기능을 개발했습니다.
- 메인 플랫폼 기반 추천: 카테고리 구분 없이, 트렌드 top10 조회 후 전달합니다.
-  관심 분야 기반 추천: 플랫폼 구분 없이, 트렌드 top10 조회 후 전달합니다.

## 🔍 참고 사항
- 관심 분야 기반 추천 응답은 하나의 리스트로 내려가지만, 카테고리 별로 묶이는 순서(카테고리 & 순위) 를 보장해 전달합니다.
- Trend 애플리케이션 계층에서 userId로 사용자 관심 카테고리를 조회해야 하기 때문에, UserInterestPort/ Adapter를 추가 구현했습니다.

## 🖼️ 스크린샷
<img width="1011" height="793" alt="스크린샷 2026-01-15 221938" src="https://github.com/user-attachments/assets/5bcf73a7-7d72-4183-9529-cbffba3678ec" />
<사용자 메인 플랫폼 기반 키워드 추천 응답>
<img width="1038" height="784" alt="스크린샷 2026-01-15 221043" src="https://github.com/user-attachments/assets/651d5bcf-e2d5-456b-ab25-333cf6d8ac79" />
<사용자 관심 분야 기반 키워드 추천 응답>

## 🔗 관련 이슈
#44 

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인