### PR TITLE
refactor: Chat getMyChatRooms N+1 제거

### DIFF
--- a/src/main/java/tave/crezipsa/crezipsa/application/chat/usecase/ChatUseCaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/chat/usecase/ChatUseCaseImpl.java
@@ -1,6 +1,7 @@
 package tave.crezipsa.crezipsa.application.chat.usecase;
 
 import java.util.List;
+import java.util.Map;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -55,13 +56,22 @@ public class ChatUseCaseImpl implements ChatUseCase {
 
 	@Override
 	public List<ChatRoomListResponse> getMyChatRooms(Long userId) {
-		return chatRoomRepository.findByUserId(userId).stream()
+		List<ChatRoom> rooms = chatRoomRepository.findByUserId(userId);
+		if (rooms.isEmpty()) {
+			return List.of();
+		}
+
+		List<Long> roomIds = rooms.stream()
+			.map(ChatRoom::getId)
+			.toList();
+		Map<Long, java.time.LocalDateTime> lastMessageAtByRoomId =
+			chatMessageRepository.findLastMessageAtByChatRoomIds(roomIds);
+
+		return rooms.stream()
 			.map(room -> new ChatRoomListResponse(
 				room.getId(),
 				room.getTitle(),
-				chatMessageRepository
-					.findLastMessageAt(room.getId())
-					.orElse(null)
+				lastMessageAtByRoomId.get(room.getId())
 			))
 			.toList();
 	}

--- a/src/main/java/tave/crezipsa/crezipsa/application/chat/usecase/ChatUseCaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/chat/usecase/ChatUseCaseImpl.java
@@ -32,7 +32,7 @@ public class ChatUseCaseImpl implements ChatUseCase {
 
 	@Override
 	public Long createChatRoom(Long userId, String title) {
-		String checkTitle = resolveChatRooomTitle(title);
+		String checkTitle = resolveChatRoomTitle(title);
 		ChatRoom room = ChatRoom.create(userId, checkTitle);
 		return chatRoomRepository.save(room).getId();
 	}
@@ -94,12 +94,6 @@ public class ChatUseCaseImpl implements ChatUseCase {
 		);
 	}
 
-	private String resolveChatRooomTitle(String title) {
-		return (title == null || title.isBlank())
-			? "새 채팅"
-			: title;
-	}
-
 	private ChatRoom getChatRoom(Long chatRoomId, Long userId) {
 		return chatRoomRepository.findByIdAndUserId(chatRoomId, userId)
 			.orElseThrow(() ->
@@ -107,13 +101,6 @@ public class ChatUseCaseImpl implements ChatUseCase {
 			);
 	}
 
-	private void validateChatRoomOwner(Long chatRoomId, Long userId) {
-		if (!chatRoomRepository
-			.findByIdAndUserId(chatRoomId, userId)
-			.isPresent()) {
-			throw new CommonException(ErrorCode.CHAT_ROOM_NOT_FOUND);
-		}
-	}
 	private String resolveChatRoomTitle(String title) {
 		return (title == null || title.isBlank())
 			? "새 채팅"

--- a/src/main/java/tave/crezipsa/crezipsa/domain/chat/port/ChatMessageRepositoryPort.java
+++ b/src/main/java/tave/crezipsa/crezipsa/domain/chat/port/ChatMessageRepositoryPort.java
@@ -2,6 +2,7 @@ package tave.crezipsa.crezipsa.domain.chat.port;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import tave.crezipsa.crezipsa.domain.chat.entity.ChatMessage;
@@ -13,5 +14,6 @@ public interface ChatMessageRepositoryPort {
 	ChatMessage findById(Long id);
 	List<ChatMessage> findByChatRoomIdOrderByCreatedAtAsc(Long chatRoomId);
 	Optional<LocalDateTime> findLastMessageAt(Long chatRoomId);
+	Map<Long, LocalDateTime> findLastMessageAtByChatRoomIds(List<Long> chatRoomIds);
 
 }

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatMessageJpaRepository.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatMessageJpaRepository.java
@@ -6,11 +6,17 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import tave.crezipsa.crezipsa.domain.chat.entity.ChatMessage;
 import tave.crezipsa.crezipsa.infrastructure.chat.entity.ChatMessageJpaEntity;
 
 public interface ChatMessageJpaRepository extends JpaRepository<ChatMessageJpaEntity, Long> {
+	interface ChatRoomLastMessageAtProjection {
+		Long getChatRoomId();
+		LocalDateTime getLastMessageAt();
+	}
+
 	List<ChatMessageJpaEntity> findByChatRoomId(Long chatRoomId);
 
 	List<ChatMessageJpaEntity>
@@ -22,4 +28,14 @@ public interface ChatMessageJpaRepository extends JpaRepository<ChatMessageJpaEn
 		where m.chatRoomId = :chatRoomId
 	""")
 	Optional<LocalDateTime> findLastMessageAt(Long chatRoomId);
+
+	@Query("""
+		select m.chatRoomId as chatRoomId, max(m.createdAt) as lastMessageAt
+		from ChatMessageJpaEntity m
+		where m.chatRoomId in :chatRoomIds
+		group by m.chatRoomId
+	""")
+	List<ChatRoomLastMessageAtProjection> findLastMessageAtByChatRoomIds(
+		@Param("chatRoomIds") List<Long> chatRoomIds
+	);
 }

--- a/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatMessageRepositoryImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatMessageRepositoryImpl.java
@@ -1,7 +1,9 @@
 package tave.crezipsa.crezipsa.infrastructure.chat.repository;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -51,5 +53,18 @@ public class ChatMessageRepositoryImpl implements ChatMessageRepositoryPort {
 	@Override
 	public Optional<LocalDateTime> findLastMessageAt(Long chatRoomId) {
 		return chatMessageJpaRepository.findLastMessageAt(chatRoomId);
+	}
+
+	@Override
+	public Map<Long, LocalDateTime> findLastMessageAtByChatRoomIds(List<Long> chatRoomIds) {
+		if (chatRoomIds == null || chatRoomIds.isEmpty()) {
+			return Collections.emptyMap();
+		}
+
+		return chatMessageJpaRepository.findLastMessageAtByChatRoomIds(chatRoomIds).stream()
+			.collect(Collectors.toMap(
+				ChatMessageJpaRepository.ChatRoomLastMessageAtProjection::getChatRoomId,
+				ChatMessageJpaRepository.ChatRoomLastMessageAtProjection::getLastMessageAt
+			));
 	}
 }


### PR DESCRIPTION
## 📌 작업한 내용
- `getMyChatRooms`에서 채팅방별 `findLastMessageAt` 반복 호출을 제거하고 배치 조회 방식으로 변경했습니다.
- `ChatMessageRepositoryPort`에 `findLastMessageAtByChatRoomIds(List<Long>)`를 추가했습니다.
- `ChatMessageJpaRepository`에 `IN + GROUP BY + MAX(createdAt)` JPQL과 projection을 추가했습니다.
- `ChatMessageRepositoryImpl`에서 배치 조회 결과를 `Map<chatRoomId, lastMessageAt>`으로 변환하도록 구현했습니다.
- 변경 파일
  - `src/main/java/tave/crezipsa/crezipsa/application/chat/usecase/ChatUseCaseImpl.java`
  - `src/main/java/tave/crezipsa/crezipsa/domain/chat/port/ChatMessageRepositoryPort.java`
  - `src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatMessageJpaRepository.java`
  - `src/main/java/tave/crezipsa/crezipsa/infrastructure/chat/repository/ChatMessageRepositoryImpl.java`

## 🔍 참고 사항
- 쿼리 패턴: 1회 채팅방 목록 조회 + 1회 마지막 메시지 집계 조회로 N+1을 제거했습니다.
- `chatRoomIds`가 비어있는 경우 `emptyMap`을 반환하도록 방어 로직을 넣었습니다.
- `./gradlew test` 로컬 실행 성공했습니다.

## 🖼️ 스크린샷
- UI 변경 없음

## 🔗 관련 이슈
- #53

## ✅ 체크리스트
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [x] 문서화 필요 여부 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Faster chat room list loading by fetching last-message timestamps in batch, reducing load time and database queries.
* **Bug Fixes**
  * Fixed chat room title resolution and ensured an empty chat-room list returns cleanly when no rooms exist, preventing errors and improving stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->