### PR TITLE
[Test] #56 community-usecase/domain 테스트 추가 및 커버리지

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,16 +1,26 @@
-
-# Gradle caches and build outputs
+# Gradle caches
 .gradle/
-**/build/
-**/out/
 buildSrc/.gradle/
-buildSrc/build/
 
 # IntelliJ / IDE
 .idea/
 *.iml
 *.ipr
 *.iws
+
+# Build outputs (ignore most, keep reports for tests/coverage)
+**/build/classes/
+**/build/kotlin/
+**/build/java/
+**/build/resources/
+**/build/generated/
+**/build/tmp/
+**/build/libs/
+**/build/distributions/
+**/build/bootRun/
+**/build/spring-boot-loader/
+**/out/
+buildSrc/build/
 
 # Logs and runtime artifacts
 logs/

--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,41 @@
+
+# Gradle caches and build outputs
+.gradle/
+**/build/
+**/out/
+buildSrc/.gradle/
+buildSrc/build/
+
+# IntelliJ / IDE
+.idea/
+*.iml
+*.ipr
+*.iws
+
+# Logs and runtime artifacts
+logs/
+*.log
+*.hprof
+hs_err_pid*
+replay_pid*
+*.pid
+
+# Env / secrets / credentials
+.env
+.env.*
+.secrets/
+secrets/
+*.jks
+*.p12
+*.pfx
+*.pem
+*.key
+*.crt
+
+# Large data / dumps (optional)
+data/
+datasets/
+dump/
+tmp/
+*.mp4
+*.pdf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+CreZipsa — a Spring Boot 3.5.x REST API for a content creator community platform. Java 17, Gradle, MySQL, JWT auth with Kakao OAuth, AWS S3 for file storage, Google Gemini API for AI chat.
+
+## Commands
+
+```bash
+./gradlew clean build                    # Full build with tests
+./gradlew test                           # Run all tests
+./gradlew test --tests "*SomeTest*"      # Run tests by pattern
+./gradlew test --tests "tave.crezipsa.crezipsa.SomeTest.someMethod"  # Single method
+./gradlew bootRun                        # Run locally (default profile: local)
+SPRING_PROFILES_ACTIVE=local ./gradlew bootRun  # Explicit profile
+```
+
+No lint/format tasks configured — follow existing file style (tabs, K&R braces).
+
+Test coverage: JaCoCo reports generated to `build/reports/jacoco/test/` after `./gradlew test`.
+
+## Architecture
+
+**Clean / Hexagonal Architecture** with four layers:
+
+| Layer | Package | Responsibility |
+|---|---|---|
+| **presentation** | `presentation/**/controller` | Thin controllers, return `GlobalResponseDto<T>`, delegate to usecases |
+| **application** | `application/**/usecase`, `dto`, `mapper` | Business orchestration, DTOs, mapping. Interfaces (`*Usecase`/`*UseCase`) + `*Impl` |
+| **domain** | `domain/**/domain`, `entity`, `repository`, `service` | Entities, value objects, repository port interfaces |
+| **infrastructure** | `infrastructure/**/repository`, `client`, `mapper`, `entity` | JPA repos, OAuth clients, S3, Gemini API, entity↔domain mappers |
+| **global** | `global/config`, `exception`, `security`, `common` | Cross-cutting: SecurityConfig, JWT, GlobalExceptionHandler, BaseEntity, GlobalResponseDto |
+
+**Port & Adapter flow:** Domain defines repository interfaces (ports) → Infrastructure implements them (adapters via JPA). Use cases depend on domain ports, never on infrastructure directly.
+
+## Key Patterns
+
+**Response envelope:** All endpoints return `GlobalResponseDto<T>` with `{ success, status, message, errorCode, result }`. Use `GlobalResponseDto.success(data)` or `GlobalResponseDto.fail(errorCode)`.
+
+**Error handling:** Throw `CommonException(ErrorCode.XXXX)` for business errors. `GlobalExceptionHandler` catches and wraps. Error codes defined in `global/exception/code/ErrorCode.java` — prefixed by domain (U=User, A=Auth, C=Community/Comment, CH=Chat, G=Gemini, SE=Search).
+
+**Entity auditing:** All JPA entities extend `BaseEntity` which provides `createdAt`/`updatedAt` via `@MappedSuperclass`.
+
+**Dual datasource:** Main MySQL (`MainDataSourceConfig`) + analytics MySQL (`AnalyticsJdbcConfig` via `NamedParameterJdbcTemplate`).
+
+**Auth:** JWT filter chain in `global/security/`. Controllers use `@AuthenticationPrincipal User user`. Public endpoints: `/api/auth/**`, `/api/user/signUp`, `/api/auth/refreshToken`.
+
+**Comments:** Support one level of nesting only (depth 0 or 1). No deeper replies.
+
+**Likes:** Composite key `LikeId(userId, communityId)`. Toggle increments/decrements `Community.likeCount`.
+
+## Conventions
+
+- **UseCase naming is inconsistent** (`CommunityUseCase` vs `CommentUsecase`) — preserve existing names, don't normalize.
+- **Domain entities** live in `domain/`; **JPA entities** live in `infrastructure/`. Keep them separate with mappers between.
+- Use `@Transactional` on usecases; `@Transactional(readOnly = true)` for queries.
+- Use `Pageable` for list endpoints. Watch for N+1 — use batch/join queries.
+- External HTTP calls use `WebClient` in `infrastructure/**/client`.
+- Tests: JUnit 5 + Mockito, `@ExtendWith(MockitoExtension.class)`, AssertJ assertions, `@DisplayName`/`@Nested` for organization. H2 in-memory DB for test runtime.
+
+## Branch Naming
+
+- `feat/#issue/description`
+- `refactor/#issue/description`
+- `test/#issue/description`
+
+## Deployment
+
+Docker-based via GitHub Actions. Configs in `docker/` with dev/prod compose files and `.env` files. CI builds JAR (`-x test`), pushes Docker image, deploys to EC2.

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.6'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'jacoco'
 }
 
 group = 'tave.crezipsa'
@@ -58,4 +59,13 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
 }

--- a/src/test/java/tave/crezipsa/crezipsa/application/chat/usecase/ChatUseCaseImplTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/application/chat/usecase/ChatUseCaseImplTest.java
@@ -5,6 +5,10 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import static tave.crezipsa.crezipsa.fixture.ChatFixture.*;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -13,6 +17,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import tave.crezipsa.crezipsa.application.chat.dto.response.ChatRoomListResponse;
 import tave.crezipsa.crezipsa.application.chat.dto.response.GeminiChatResponse;
 import tave.crezipsa.crezipsa.domain.chat.entity.ChatMessage;
 import tave.crezipsa.crezipsa.domain.chat.entity.ChatRoom;
@@ -119,6 +124,48 @@ class ChatUseCaseImplTest {
 
 			// then
 			verify(chatRoomRepository).changeTitle(10L, 1L, "새 제목");
+		}
+	}
+
+	@Nested
+	@DisplayName("getMyChatRooms")
+	class GetMyChatRooms {
+
+		@Test
+		@DisplayName("채팅방이 없으면 빈 목록 반환")
+		void noRooms_returnsEmpty() {
+			// given
+			when(chatRoomRepository.findByUserId(1L)).thenReturn(List.of());
+
+			// when
+			List<ChatRoomListResponse> result = sut.getMyChatRooms(1L);
+
+			// then
+			assertThat(result).isEmpty();
+			verify(chatMessageRepository, never()).findLastMessageAtByChatRoomIds(anyList());
+		}
+
+		@Test
+		@DisplayName("채팅방 목록과 마지막 메시지 시간 조합하여 반환")
+		void hasRooms_returnsWithLastMessageAt() {
+			// given
+			Long userId = 1L;
+			ChatRoom room1 = createChatRoom(10L, userId);
+			ChatRoom room2 = createChatRoom(11L, userId);
+			LocalDateTime now = LocalDateTime.now();
+
+			when(chatRoomRepository.findByUserId(userId)).thenReturn(List.of(room1, room2));
+			when(chatMessageRepository.findLastMessageAtByChatRoomIds(List.of(10L, 11L)))
+				.thenReturn(Map.of(10L, now, 11L, now.minusHours(1)));
+
+			// when
+			List<ChatRoomListResponse> result = sut.getMyChatRooms(userId);
+
+			// then
+			assertThat(result).hasSize(2);
+			assertThat(result.get(0).chatRoomId()).isEqualTo(10L);
+			assertThat(result.get(0).lastMessageAt()).isEqualTo(now);
+			assertThat(result.get(1).chatRoomId()).isEqualTo(11L);
 		}
 	}
 }

--- a/src/test/java/tave/crezipsa/crezipsa/application/chat/usecase/ChatUseCaseImplTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/application/chat/usecase/ChatUseCaseImplTest.java
@@ -1,0 +1,80 @@
+package tave.crezipsa.crezipsa.application.chat.usecase;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static tave.crezipsa.crezipsa.fixture.ChatFixture.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import tave.crezipsa.crezipsa.domain.chat.entity.ChatRoom;
+import tave.crezipsa.crezipsa.domain.chat.port.ChatMessageRepositoryPort;
+import tave.crezipsa.crezipsa.domain.chat.port.ChatRoomRepositoryPort;
+import tave.crezipsa.crezipsa.domain.storyboard.port.StoryboardGeneratorPort;
+
+@ExtendWith(MockitoExtension.class)
+class ChatUseCaseImplTest {
+
+	@Mock
+	private ChatRoomRepositoryPort chatRoomRepository;
+	@Mock
+	private ChatMessageRepositoryPort chatMessageRepository;
+	@Mock
+	private StoryboardGeneratorPort storyboardGeneratorPort;
+
+	@InjectMocks
+	private ChatUseCaseImpl sut;
+
+	@Nested
+	@DisplayName("createChatRoom")
+	class CreateChatRoom {
+
+		@Test
+		@DisplayName("제목이 null이면 기본 제목으로 생성")
+		void nullTitle_usesDefault() {
+			// given
+			ChatRoom saved = createChatRoom(1L, 1L);
+			when(chatRoomRepository.save(any(ChatRoom.class))).thenReturn(saved);
+
+			// when
+			Long result = sut.createChatRoom(1L, null);
+
+			// then
+			assertThat(result).isEqualTo(1L);
+		}
+
+		@Test
+		@DisplayName("제목이 빈 문자열이면 기본 제목으로 생성")
+		void blankTitle_usesDefault() {
+			// given
+			ChatRoom saved = createChatRoom(1L, 1L);
+			when(chatRoomRepository.save(any(ChatRoom.class))).thenReturn(saved);
+
+			// when
+			Long result = sut.createChatRoom(1L, "   ");
+
+			// then
+			assertThat(result).isEqualTo(1L);
+		}
+
+		@Test
+		@DisplayName("제목이 있으면 해당 제목으로 생성")
+		void validTitle_createsWithTitle() {
+			// given
+			ChatRoom saved = createChatRoom(1L, 1L);
+			when(chatRoomRepository.save(any(ChatRoom.class))).thenReturn(saved);
+
+			// when
+			Long result = sut.createChatRoom(1L, "내 채팅방");
+
+			// then
+			assertThat(result).isEqualTo(1L);
+		}
+	}
+}

--- a/src/test/java/tave/crezipsa/crezipsa/application/chat/usecase/ChatUseCaseImplTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/application/chat/usecase/ChatUseCaseImplTest.java
@@ -13,6 +13,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import tave.crezipsa.crezipsa.application.chat.dto.response.GeminiChatResponse;
+import tave.crezipsa.crezipsa.domain.chat.entity.ChatMessage;
 import tave.crezipsa.crezipsa.domain.chat.entity.ChatRoom;
 import tave.crezipsa.crezipsa.domain.chat.port.ChatMessageRepositoryPort;
 import tave.crezipsa.crezipsa.domain.chat.port.ChatRoomRepositoryPort;
@@ -75,6 +77,33 @@ class ChatUseCaseImplTest {
 
 			// then
 			assertThat(result).isEqualTo(1L);
+		}
+	}
+
+	@Nested
+	@DisplayName("sendUserMessage")
+	class SendUserMessage {
+
+		@Test
+		@DisplayName("사용자 메시지 저장 후 AI 응답 저장 및 반환")
+		void savesUserAndAiMessages() {
+			// given
+			Long chatRoomId = 1L;
+			Long userId = 1L;
+			String userMsg = "스토리보드 만들어줘";
+			String aiReply = "AI 응답입니다";
+
+			when(chatMessageRepository.save(any(ChatMessage.class)))
+				.thenAnswer(invocation -> invocation.getArgument(0));
+			when(storyboardGeneratorPort.generate(userMsg)).thenReturn(aiReply);
+
+			// when
+			GeminiChatResponse result = sut.sendUserMessage(chatRoomId, userId, userMsg);
+
+			// then
+			assertThat(result.content()).isEqualTo(aiReply);
+			verify(chatMessageRepository, times(2)).save(any(ChatMessage.class));
+			verify(storyboardGeneratorPort).generate(userMsg);
 		}
 	}
 }

--- a/src/test/java/tave/crezipsa/crezipsa/application/chat/usecase/ChatUseCaseImplTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/application/chat/usecase/ChatUseCaseImplTest.java
@@ -8,6 +8,7 @@ import static tave.crezipsa.crezipsa.fixture.ChatFixture.*;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -17,6 +18,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import tave.crezipsa.crezipsa.application.chat.dto.response.ChatMessageResponse;
 import tave.crezipsa.crezipsa.application.chat.dto.response.ChatRoomListResponse;
 import tave.crezipsa.crezipsa.application.chat.dto.response.GeminiChatResponse;
 import tave.crezipsa.crezipsa.domain.chat.entity.ChatMessage;
@@ -24,6 +26,8 @@ import tave.crezipsa.crezipsa.domain.chat.entity.ChatRoom;
 import tave.crezipsa.crezipsa.domain.chat.port.ChatMessageRepositoryPort;
 import tave.crezipsa.crezipsa.domain.chat.port.ChatRoomRepositoryPort;
 import tave.crezipsa.crezipsa.domain.storyboard.port.StoryboardGeneratorPort;
+import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
+import tave.crezipsa.crezipsa.global.exception.model.CommonException;
 
 @ExtendWith(MockitoExtension.class)
 class ChatUseCaseImplTest {
@@ -166,6 +170,48 @@ class ChatUseCaseImplTest {
 			assertThat(result.get(0).chatRoomId()).isEqualTo(10L);
 			assertThat(result.get(0).lastMessageAt()).isEqualTo(now);
 			assertThat(result.get(1).chatRoomId()).isEqualTo(11L);
+		}
+	}
+
+	@Nested
+	@DisplayName("getChatDetail")
+	class GetChatDetail {
+
+		@Test
+		@DisplayName("채팅방이 없거나 본인 것이 아니면 CHAT_ROOM_NOT_FOUND 예외")
+		void notFound_throws() {
+			// given
+			when(chatRoomRepository.findByIdAndUserId(1L, 1L)).thenReturn(Optional.empty());
+
+			// when & then
+			assertThatThrownBy(() -> sut.getChatDetail(1L, 1L))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.CHAT_ROOM_NOT_FOUND);
+		}
+
+		@Test
+		@DisplayName("본인 채팅방이면 메시지 목록과 함께 반환")
+		void owner_returnsWithMessages() {
+			// given
+			Long userId = 1L;
+			Long chatRoomId = 10L;
+			ChatRoom room = createChatRoom(chatRoomId, userId);
+			ChatMessage userMsg = createUserMessage(100L, chatRoomId);
+			ChatMessage aiMsg = createAiMessage(101L, chatRoomId);
+
+			when(chatRoomRepository.findByIdAndUserId(chatRoomId, userId)).thenReturn(Optional.of(room));
+			when(chatMessageRepository.findByChatRoomIdOrderByCreatedAtAsc(chatRoomId))
+				.thenReturn(List.of(userMsg, aiMsg));
+
+			// when
+			ChatMessageResponse result = sut.getChatDetail(userId, chatRoomId);
+
+			// then
+			assertThat(result.chatRoomId()).isEqualTo(chatRoomId);
+			assertThat(result.messages()).hasSize(2);
+			assertThat(result.messages().get(0).senderType()).isEqualTo(ChatMessage.SenderType.USER);
+			assertThat(result.messages().get(1).senderType()).isEqualTo(ChatMessage.SenderType.AI);
 		}
 	}
 }

--- a/src/test/java/tave/crezipsa/crezipsa/application/chat/usecase/ChatUseCaseImplTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/application/chat/usecase/ChatUseCaseImplTest.java
@@ -106,4 +106,19 @@ class ChatUseCaseImplTest {
 			verify(storyboardGeneratorPort).generate(userMsg);
 		}
 	}
+
+	@Nested
+	@DisplayName("changeChatRoomTitle")
+	class ChangeChatRoomTitle {
+
+		@Test
+		@DisplayName("채팅방 제목 변경 위임")
+		void delegatesToRepository() {
+			// when
+			sut.changeChatRoomTitle(1L, 10L, "새 제목");
+
+			// then
+			verify(chatRoomRepository).changeTitle(10L, 1L, "새 제목");
+		}
+	}
 }

--- a/src/test/java/tave/crezipsa/crezipsa/application/community/usecase/CommentUseCaseImplTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/application/community/usecase/CommentUseCaseImplTest.java
@@ -3,8 +3,10 @@ package tave.crezipsa.crezipsa.application.community.usecase;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static tave.crezipsa.crezipsa.fixture.CommentFixture.*;
+import static tave.crezipsa.crezipsa.fixture.CommunityFixture.*;
+import static tave.crezipsa.crezipsa.fixture.UserFixture.*;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,7 +17,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import tave.crezipsa.crezipsa.application.community.dto.request.CommentCreateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommentUpdateRequest;
@@ -24,11 +25,9 @@ import tave.crezipsa.crezipsa.application.community.dto.response.WriterResponse;
 import tave.crezipsa.crezipsa.application.community.mapper.CommentMapper;
 import tave.crezipsa.crezipsa.domain.community.domain.Comment;
 import tave.crezipsa.crezipsa.domain.community.domain.Community;
-import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
 import tave.crezipsa.crezipsa.domain.community.repository.CommentRepository;
 import tave.crezipsa.crezipsa.domain.community.repository.CommunityRepository;
 import tave.crezipsa.crezipsa.domain.user.entity.User;
-import tave.crezipsa.crezipsa.domain.user.enums.Platform;
 import tave.crezipsa.crezipsa.domain.user.repository.UserRepository;
 import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
 import tave.crezipsa.crezipsa.global.exception.model.CommonException;
@@ -55,6 +54,7 @@ class CommentUseCaseImplTest {
 		@Test
 		@DisplayName("대댓글의 대댓글 시도 시 INVALID_COMMENT_DEPTH 예외")
 		void replyToReply_throwsInvalidDepth() {
+			// given
 			Long communityId = 1L;
 			Community community = createCommunity(communityId);
 			Comment parentReply = createComment(2L, communityId, 1L, 1L);
@@ -64,6 +64,7 @@ class CommentUseCaseImplTest {
 
 			CommentCreateRequest request = new CommentCreateRequest(2L, "reply to reply");
 
+			// when & then
 			assertThatThrownBy(() -> sut.createComment(communityId, 1L, request))
 				.isInstanceOf(CommonException.class)
 				.extracting("errorCode")
@@ -73,6 +74,7 @@ class CommentUseCaseImplTest {
 		@Test
 		@DisplayName("다른 게시글의 댓글에 대댓글 시도 시 INVALID_PARENT_COMMUNITY 예외")
 		void replyToDifferentCommunity_throwsInvalidParent() {
+			// given
 			Long communityId = 1L;
 			Community community = createCommunity(communityId);
 			Comment parentFromOtherPost = createComment(10L, 999L, 1L, null);
@@ -82,6 +84,7 @@ class CommentUseCaseImplTest {
 
 			CommentCreateRequest request = new CommentCreateRequest(10L, "cross-post reply");
 
+			// when & then
 			assertThatThrownBy(() -> sut.createComment(communityId, 1L, request))
 				.isInstanceOf(CommonException.class)
 				.extracting("errorCode")
@@ -91,10 +94,11 @@ class CommentUseCaseImplTest {
 		@Test
 		@DisplayName("존재하지 않는 게시글이면 COMMUNITY_NOT_FOUND 예외")
 		void communityNotFound_throws() {
+			// given
 			when(communityRepository.findById(1L)).thenReturn(Optional.empty());
-
 			CommentCreateRequest request = new CommentCreateRequest(null, "content");
 
+			// when & then
 			assertThatThrownBy(() -> sut.createComment(1L, 1L, request))
 				.isInstanceOf(CommonException.class)
 				.extracting("errorCode")
@@ -109,11 +113,14 @@ class CommentUseCaseImplTest {
 		@Test
 		@DisplayName("루트 댓글은 소프트 삭제 (deleted=true, 내용 변경)")
 		void rootComment_softDeletes() {
+			// given
 			Comment rootComment = createComment(1L, 1L, 100L, null);
 			when(commentRepository.findById(1L)).thenReturn(Optional.of(rootComment));
 
+			// when
 			sut.deleteComment(1L, 100L);
 
+			// then
 			assertThat(rootComment.isDeleted()).isTrue();
 			assertThat(rootComment.getContent()).isEqualTo("삭제된 메시지입니다");
 			verify(commentRepository, never()).delete(any());
@@ -122,11 +129,14 @@ class CommentUseCaseImplTest {
 		@Test
 		@DisplayName("자식 댓글은 하드 삭제 (DB에서 제거)")
 		void childComment_hardDeletes() {
+			// given
 			Comment childComment = createComment(2L, 1L, 100L, 1L);
 			when(commentRepository.findById(2L)).thenReturn(Optional.of(childComment));
 
+			// when
 			sut.deleteComment(2L, 100L);
 
+			// then
 			assertThat(childComment.isDeleted()).isFalse();
 			verify(commentRepository).delete(childComment);
 		}
@@ -134,9 +144,11 @@ class CommentUseCaseImplTest {
 		@Test
 		@DisplayName("작성자가 아니면 UNAUTHORIZED_COMMENT 예외")
 		void nonWriter_throwsUnauthorized() {
+			// given
 			Comment comment = createComment(1L, 1L, 100L, null);
 			when(commentRepository.findById(1L)).thenReturn(Optional.of(comment));
 
+			// when & then
 			assertThatThrownBy(() -> sut.deleteComment(1L, 999L))
 				.isInstanceOf(CommonException.class)
 				.extracting("errorCode")
@@ -151,9 +163,11 @@ class CommentUseCaseImplTest {
 		@Test
 		@DisplayName("작성자가 아니면 UNAUTHORIZED_COMMENT 예외")
 		void nonWriter_throwsUnauthorized() {
+			// given
 			Comment comment = createComment(1L, 1L, 100L, null);
 			when(commentRepository.findById(1L)).thenReturn(Optional.of(comment));
 
+			// when & then
 			assertThatThrownBy(() -> sut.updateComment(1L, 999L, new CommentUpdateRequest("new")))
 				.isInstanceOf(CommonException.class)
 				.extracting("errorCode")
@@ -168,6 +182,7 @@ class CommentUseCaseImplTest {
 		@Test
 		@DisplayName("루트 댓글과 자식 댓글을 트리 구조로 조합")
 		void buildsNestedTree() {
+			// given
 			Long communityId = 1L;
 			Long viewerId = 50L;
 			Community community = createCommunity(communityId);
@@ -198,8 +213,10 @@ class CommentUseCaseImplTest {
 					);
 				});
 
+			// when
 			List<CommentResponse> result = sut.getComments(communityId, viewerId);
 
+			// then
 			assertThat(result).hasSize(2);
 
 			CommentResponse firstRoot = result.get(0);
@@ -215,14 +232,17 @@ class CommentUseCaseImplTest {
 		@Test
 		@DisplayName("빈 댓글 목록이면 빈 리스트 반환하고 User 조회 안 함")
 		void emptyComments_returnsEmptyAndSkipsUserLookup() {
+			// given
 			Long communityId = 1L;
 			Community community = createCommunity(communityId);
 
 			when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
 			when(commentRepository.findByCommunityId(communityId)).thenReturn(List.of());
 
+			// when
 			List<CommentResponse> result = sut.getComments(communityId, 1L);
 
+			// then
 			assertThat(result).isEmpty();
 			verify(userRepository, never()).findAllById(any());
 		}
@@ -230,6 +250,7 @@ class CommentUseCaseImplTest {
 		@Test
 		@DisplayName("댓글 작성자의 writerMap에 없는 userId가 있으면 USER_NOT_FOUND 예외")
 		void writerNotInMap_throwsUserNotFound() {
+			// given
 			Long communityId = 1L;
 			Community community = createCommunity(communityId);
 			Comment comment = createComment(1L, communityId, 999L, null);
@@ -238,49 +259,11 @@ class CommentUseCaseImplTest {
 			when(commentRepository.findByCommunityId(communityId)).thenReturn(List.of(comment));
 			when(userRepository.findAllById(any())).thenReturn(List.of());
 
+			// when & then
 			assertThatThrownBy(() -> sut.getComments(communityId, 1L))
 				.isInstanceOf(CommonException.class)
 				.extracting("errorCode")
 				.isEqualTo(ErrorCode.USER_NOT_FOUND);
 		}
-	}
-
-	// ── 헬퍼 메서드 ──
-
-	private Community createCommunity(Long id) {
-		Community community = Community.builder()
-			.communityId(id)
-			.title("test")
-			.content("content content content content content content content")
-			.field(CommunityField.RECOMMEND)
-			.imageUrls(List.of())
-			.writerId(1L)
-			.likeCount(0L)
-			.build();
-		ReflectionTestUtils.setField(community, "createdAt", LocalDateTime.now());
-		return community;
-	}
-
-	private Comment createComment(Long commentId, Long communityId, Long userId, Long parentId) {
-		Comment comment = Comment.builder()
-			.commentId(commentId)
-			.communityId(communityId)
-			.userId(userId)
-			.content("test comment")
-			.parentId(parentId)
-			.build();
-		ReflectionTestUtils.setField(comment, "createdAt", LocalDateTime.now());
-		return comment;
-	}
-
-	private User createUser(Long userId) {
-		return User.builder()
-			.userId(userId)
-			.nickName("user" + userId)
-			.email("user" + userId + "@test.com")
-			.profileImageUrl("profile.jpg")
-			.mainPlatform(Platform.YOUTUBE)
-			.activeYoutube("yt" + userId)
-			.build();
 	}
 }

--- a/src/test/java/tave/crezipsa/crezipsa/application/community/usecase/CommentUseCaseImplTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/application/community/usecase/CommentUseCaseImplTest.java
@@ -1,0 +1,286 @@
+package tave.crezipsa.crezipsa.application.community.usecase;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import tave.crezipsa.crezipsa.application.community.dto.request.CommentCreateRequest;
+import tave.crezipsa.crezipsa.application.community.dto.request.CommentUpdateRequest;
+import tave.crezipsa.crezipsa.application.community.dto.response.CommentResponse;
+import tave.crezipsa.crezipsa.application.community.dto.response.WriterResponse;
+import tave.crezipsa.crezipsa.application.community.mapper.CommentMapper;
+import tave.crezipsa.crezipsa.domain.community.domain.Comment;
+import tave.crezipsa.crezipsa.domain.community.domain.Community;
+import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
+import tave.crezipsa.crezipsa.domain.community.repository.CommentRepository;
+import tave.crezipsa.crezipsa.domain.community.repository.CommunityRepository;
+import tave.crezipsa.crezipsa.domain.user.entity.User;
+import tave.crezipsa.crezipsa.domain.user.enums.Platform;
+import tave.crezipsa.crezipsa.domain.user.repository.UserRepository;
+import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
+import tave.crezipsa.crezipsa.global.exception.model.CommonException;
+
+@ExtendWith(MockitoExtension.class)
+class CommentUseCaseImplTest {
+
+	@Mock
+	private CommentRepository commentRepository;
+	@Mock
+	private CommunityRepository communityRepository;
+	@Mock
+	private UserRepository userRepository;
+	@Mock
+	private CommentMapper commentMapper;
+
+	@InjectMocks
+	private CommentUseCaseImpl sut;
+
+	@Nested
+	@DisplayName("createComment")
+	class CreateComment {
+
+		@Test
+		@DisplayName("대댓글의 대댓글 시도 시 INVALID_COMMENT_DEPTH 예외")
+		void replyToReply_throwsInvalidDepth() {
+			Long communityId = 1L;
+			Community community = createCommunity(communityId);
+			Comment parentReply = createComment(2L, communityId, 1L, 1L);
+
+			when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
+			when(commentRepository.findById(2L)).thenReturn(Optional.of(parentReply));
+
+			CommentCreateRequest request = new CommentCreateRequest(2L, "reply to reply");
+
+			assertThatThrownBy(() -> sut.createComment(communityId, 1L, request))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.INVALID_COMMENT_DEPTH);
+		}
+
+		@Test
+		@DisplayName("다른 게시글의 댓글에 대댓글 시도 시 INVALID_PARENT_COMMUNITY 예외")
+		void replyToDifferentCommunity_throwsInvalidParent() {
+			Long communityId = 1L;
+			Community community = createCommunity(communityId);
+			Comment parentFromOtherPost = createComment(10L, 999L, 1L, null);
+
+			when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
+			when(commentRepository.findById(10L)).thenReturn(Optional.of(parentFromOtherPost));
+
+			CommentCreateRequest request = new CommentCreateRequest(10L, "cross-post reply");
+
+			assertThatThrownBy(() -> sut.createComment(communityId, 1L, request))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.INVALID_PARENT_COMMUNITY);
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 게시글이면 COMMUNITY_NOT_FOUND 예외")
+		void communityNotFound_throws() {
+			when(communityRepository.findById(1L)).thenReturn(Optional.empty());
+
+			CommentCreateRequest request = new CommentCreateRequest(null, "content");
+
+			assertThatThrownBy(() -> sut.createComment(1L, 1L, request))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.COMMUNITY_NOT_FOUND);
+		}
+	}
+
+	@Nested
+	@DisplayName("deleteComment")
+	class DeleteComment {
+
+		@Test
+		@DisplayName("루트 댓글은 소프트 삭제 (deleted=true, 내용 변경)")
+		void rootComment_softDeletes() {
+			Comment rootComment = createComment(1L, 1L, 100L, null);
+			when(commentRepository.findById(1L)).thenReturn(Optional.of(rootComment));
+
+			sut.deleteComment(1L, 100L);
+
+			assertThat(rootComment.isDeleted()).isTrue();
+			assertThat(rootComment.getContent()).isEqualTo("삭제된 메시지입니다");
+			verify(commentRepository, never()).delete(any());
+		}
+
+		@Test
+		@DisplayName("자식 댓글은 하드 삭제 (DB에서 제거)")
+		void childComment_hardDeletes() {
+			Comment childComment = createComment(2L, 1L, 100L, 1L);
+			when(commentRepository.findById(2L)).thenReturn(Optional.of(childComment));
+
+			sut.deleteComment(2L, 100L);
+
+			assertThat(childComment.isDeleted()).isFalse();
+			verify(commentRepository).delete(childComment);
+		}
+
+		@Test
+		@DisplayName("작성자가 아니면 UNAUTHORIZED_COMMENT 예외")
+		void nonWriter_throwsUnauthorized() {
+			Comment comment = createComment(1L, 1L, 100L, null);
+			when(commentRepository.findById(1L)).thenReturn(Optional.of(comment));
+
+			assertThatThrownBy(() -> sut.deleteComment(1L, 999L))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.UNAUTHORIZED_COMMENT);
+		}
+	}
+
+	@Nested
+	@DisplayName("updateComment")
+	class UpdateComment {
+
+		@Test
+		@DisplayName("작성자가 아니면 UNAUTHORIZED_COMMENT 예외")
+		void nonWriter_throwsUnauthorized() {
+			Comment comment = createComment(1L, 1L, 100L, null);
+			when(commentRepository.findById(1L)).thenReturn(Optional.of(comment));
+
+			assertThatThrownBy(() -> sut.updateComment(1L, 999L, new CommentUpdateRequest("new")))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.UNAUTHORIZED_COMMENT);
+		}
+	}
+
+	@Nested
+	@DisplayName("getComments")
+	class GetComments {
+
+		@Test
+		@DisplayName("루트 댓글과 자식 댓글을 트리 구조로 조합")
+		void buildsNestedTree() {
+			Long communityId = 1L;
+			Long viewerId = 50L;
+			Community community = createCommunity(communityId);
+
+			Comment root1 = createComment(1L, communityId, 10L, null);
+			Comment child1 = createComment(2L, communityId, 20L, 1L);
+			Comment root2 = createComment(3L, communityId, 30L, null);
+
+			User user10 = createUser(10L);
+			User user20 = createUser(20L);
+			User user30 = createUser(30L);
+
+			when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
+			when(commentRepository.findByCommunityId(communityId)).thenReturn(List.of(root1, child1, root2));
+			when(userRepository.findAllById(any())).thenReturn(List.of(user10, user20, user30));
+
+			when(commentMapper.toCommentResponse(any(), any(), anyBoolean(), anyString(), anyList()))
+				.thenAnswer(invocation -> {
+					Comment c = invocation.getArgument(0);
+					User w = invocation.getArgument(1);
+					boolean isW = invocation.getArgument(2);
+					String rt = invocation.getArgument(3);
+					List<CommentResponse> replies = invocation.getArgument(4);
+					return new CommentResponse(
+						c.getCommentId(), c.getCommunityId(), c.getParentId(),
+						WriterResponse.from(w), isW, c.isDeleted(), c.getContent(),
+						c.getCreatedAt(), rt, replies
+					);
+				});
+
+			List<CommentResponse> result = sut.getComments(communityId, viewerId);
+
+			assertThat(result).hasSize(2);
+
+			CommentResponse firstRoot = result.get(0);
+			assertThat(firstRoot.commentId()).isEqualTo(1L);
+			assertThat(firstRoot.replies()).hasSize(1);
+			assertThat(firstRoot.replies().get(0).commentId()).isEqualTo(2L);
+
+			CommentResponse secondRoot = result.get(1);
+			assertThat(secondRoot.commentId()).isEqualTo(3L);
+			assertThat(secondRoot.replies()).isEmpty();
+		}
+
+		@Test
+		@DisplayName("빈 댓글 목록이면 빈 리스트 반환하고 User 조회 안 함")
+		void emptyComments_returnsEmptyAndSkipsUserLookup() {
+			Long communityId = 1L;
+			Community community = createCommunity(communityId);
+
+			when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
+			when(commentRepository.findByCommunityId(communityId)).thenReturn(List.of());
+
+			List<CommentResponse> result = sut.getComments(communityId, 1L);
+
+			assertThat(result).isEmpty();
+			verify(userRepository, never()).findAllById(any());
+		}
+
+		@Test
+		@DisplayName("댓글 작성자의 writerMap에 없는 userId가 있으면 USER_NOT_FOUND 예외")
+		void writerNotInMap_throwsUserNotFound() {
+			Long communityId = 1L;
+			Community community = createCommunity(communityId);
+			Comment comment = createComment(1L, communityId, 999L, null);
+
+			when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
+			when(commentRepository.findByCommunityId(communityId)).thenReturn(List.of(comment));
+			when(userRepository.findAllById(any())).thenReturn(List.of());
+
+			assertThatThrownBy(() -> sut.getComments(communityId, 1L))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.USER_NOT_FOUND);
+		}
+	}
+
+	// ── 헬퍼 메서드 ──
+
+	private Community createCommunity(Long id) {
+		Community community = Community.builder()
+			.communityId(id)
+			.title("test")
+			.content("content content content content content content content")
+			.field(CommunityField.RECOMMEND)
+			.imageUrls(List.of())
+			.writerId(1L)
+			.likeCount(0L)
+			.build();
+		ReflectionTestUtils.setField(community, "createdAt", LocalDateTime.now());
+		return community;
+	}
+
+	private Comment createComment(Long commentId, Long communityId, Long userId, Long parentId) {
+		Comment comment = Comment.builder()
+			.commentId(commentId)
+			.communityId(communityId)
+			.userId(userId)
+			.content("test comment")
+			.parentId(parentId)
+			.build();
+		ReflectionTestUtils.setField(comment, "createdAt", LocalDateTime.now());
+		return comment;
+	}
+
+	private User createUser(Long userId) {
+		return User.builder()
+			.userId(userId)
+			.nickName("user" + userId)
+			.email("user" + userId + "@test.com")
+			.profileImageUrl("profile.jpg")
+			.mainPlatform(Platform.YOUTUBE)
+			.activeYoutube("yt" + userId)
+			.build();
+	}
+}

--- a/src/test/java/tave/crezipsa/crezipsa/application/community/usecase/CommunityUseCaseImplTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/application/community/usecase/CommunityUseCaseImplTest.java
@@ -1,0 +1,271 @@
+package tave.crezipsa.crezipsa.application.community.usecase;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import tave.crezipsa.crezipsa.application.community.dto.request.CommunityUpdateRequest;
+import tave.crezipsa.crezipsa.application.community.dto.response.CommunityDetailResponse;
+import tave.crezipsa.crezipsa.application.community.dto.response.CommunitySummaryResponse;
+import tave.crezipsa.crezipsa.domain.community.domain.Community;
+import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
+import tave.crezipsa.crezipsa.domain.community.domain.Like;
+import tave.crezipsa.crezipsa.domain.community.domain.LikeId;
+import tave.crezipsa.crezipsa.domain.community.repository.CommentRepository;
+import tave.crezipsa.crezipsa.domain.community.repository.CommunityRepository;
+import tave.crezipsa.crezipsa.domain.community.repository.LikeRepository;
+import tave.crezipsa.crezipsa.domain.user.entity.User;
+import tave.crezipsa.crezipsa.domain.user.enums.Platform;
+import tave.crezipsa.crezipsa.domain.user.repository.UserRepository;
+import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
+import tave.crezipsa.crezipsa.global.exception.model.CommonException;
+
+@ExtendWith(MockitoExtension.class)
+class CommunityUseCaseImplTest {
+
+	@Mock
+	private CommunityRepository communityRepository;
+	@Mock
+	private LikeRepository likeRepository;
+	@Mock
+	private CommentRepository commentRepository;
+	@Mock
+	private UserRepository userRepository;
+	@Mock
+	private CommentUsecase commentUsecase;
+
+	@InjectMocks
+	private CommunityUseCaseImpl sut;
+
+	@Nested
+	@DisplayName("updateCommunity")
+	class UpdateCommunity {
+
+		@Test
+		@DisplayName("작성자가 아니면 UNAUTHORIZED_COMMUNITY 예외")
+		void nonWriter_throwsUnauthorized() {
+			Community community = createCommunity(1L, 100L);
+			when(communityRepository.findById(1L)).thenReturn(Optional.of(community));
+
+			assertThatThrownBy(() -> sut.updateCommunity(1L, 999L, new CommunityUpdateRequest()))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.UNAUTHORIZED_COMMUNITY);
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 게시글이면 COMMUNITY_NOT_FOUND 예외")
+		void notFound_throwsCommunityNotFound() {
+			when(communityRepository.findById(1L)).thenReturn(Optional.empty());
+
+			assertThatThrownBy(() -> sut.updateCommunity(1L, 1L, new CommunityUpdateRequest()))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.COMMUNITY_NOT_FOUND);
+		}
+
+		@Test
+		@DisplayName("작성자가 맞으면 정상 업데이트")
+		void writer_updatesSuccessfully() {
+			Community community = createCommunity(1L, 100L);
+			when(communityRepository.findById(1L)).thenReturn(Optional.of(community));
+
+			CommunityUpdateRequest request = new CommunityUpdateRequest();
+			ReflectionTestUtils.setField(request, "title", "updated title");
+
+			var result = sut.updateCommunity(1L, 100L, request);
+
+			assertThat(result.title()).isEqualTo("updated title");
+			assertThat(result.content()).isEqualTo("테스트 내용입니다. 충분히 긴 내용으로 preview 테스트도 가능합니다.");
+		}
+	}
+
+	@Nested
+	@DisplayName("deleteCommunity")
+	class DeleteCommunity {
+
+		@Test
+		@DisplayName("작성자가 아니면 UNAUTHORIZED_COMMUNITY 예외")
+		void nonWriter_throwsUnauthorized() {
+			Community community = createCommunity(1L, 100L);
+			when(communityRepository.findById(1L)).thenReturn(Optional.of(community));
+
+			assertThatThrownBy(() -> sut.deleteCommunity(999L, 1L))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.UNAUTHORIZED_COMMUNITY);
+		}
+
+		@Test
+		@DisplayName("작성자가 맞으면 정상 삭제")
+		void writer_deletesSuccessfully() {
+			Community community = createCommunity(1L, 100L);
+			when(communityRepository.findById(1L)).thenReturn(Optional.of(community));
+
+			sut.deleteCommunity(100L, 1L);
+
+			verify(communityRepository).delete(community);
+		}
+	}
+
+	@Nested
+	@DisplayName("getCommunity")
+	class GetCommunity {
+
+		@Test
+		@DisplayName("상세 정보를 올바르게 조합 - 다른 사용자가 좋아요한 게시글")
+		void assembliesDetailCorrectly() {
+			Long communityId = 1L;
+			Long writerId = 10L;
+			Long viewerId = 20L;
+
+			Community community = createCommunity(communityId, writerId);
+			User writer = createUser(writerId);
+			Like like = Like.of(viewerId, communityId);
+
+			when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
+			when(userRepository.findById(writerId)).thenReturn(Optional.of(writer));
+			when(commentRepository.countByCommunityId(communityId)).thenReturn(5L);
+			when(commentUsecase.getComments(communityId, viewerId)).thenReturn(List.of());
+			when(likeRepository.findById(new LikeId(viewerId, communityId))).thenReturn(Optional.of(like));
+
+			CommunityDetailResponse result = sut.getCommunity(communityId, viewerId);
+
+			assertThat(result.communityId()).isEqualTo(communityId);
+			assertThat(result.isWriter()).isFalse();
+			assertThat(result.isLiked()).isTrue();
+			assertThat(result.commentCount()).isEqualTo(5L);
+			assertThat(result.writer().userId()).isEqualTo(writerId);
+		}
+
+		@Test
+		@DisplayName("좋아요 기록 없으면 isLiked=false, 본인 게시글이면 isWriter=true")
+		void noLike_isLikedFalse_ownPost_isWriterTrue() {
+			Long communityId = 1L;
+			Long writerId = 10L;
+
+			Community community = createCommunity(communityId, writerId);
+			User writer = createUser(writerId);
+
+			when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
+			when(userRepository.findById(writerId)).thenReturn(Optional.of(writer));
+			when(commentRepository.countByCommunityId(communityId)).thenReturn(0L);
+			when(commentUsecase.getComments(communityId, writerId)).thenReturn(List.of());
+			when(likeRepository.findById(any(LikeId.class))).thenReturn(Optional.empty());
+
+			CommunityDetailResponse result = sut.getCommunity(communityId, writerId);
+
+			assertThat(result.isLiked()).isFalse();
+			assertThat(result.isWriter()).isTrue();
+		}
+	}
+
+	@Nested
+	@DisplayName("searchCommunities")
+	class SearchCommunities {
+
+		@Test
+		@DisplayName("null 키워드면 SEARCH_KEYWORD_REQUIRED 예외")
+		void nullKeyword_throws() {
+			assertThatThrownBy(() -> sut.searchCommunities(null, null, "latest", 0, 10))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.SEARCH_KEYWORD_REQUIRED);
+		}
+
+		@Test
+		@DisplayName("빈 키워드면 SEARCH_KEYWORD_REQUIRED 예외")
+		void blankKeyword_throws() {
+			assertThatThrownBy(() -> sut.searchCommunities("   ", null, "latest", 0, 10))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.SEARCH_KEYWORD_REQUIRED);
+		}
+
+		@Test
+		@DisplayName("30자 초과 키워드면 SEARCH_KEYWORD_TOO_LONG 예외")
+		void tooLongKeyword_throws() {
+			String longKeyword = "a".repeat(31);
+
+			assertThatThrownBy(() -> sut.searchCommunities(longKeyword, null, "latest", 0, 10))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.SEARCH_KEYWORD_TOO_LONG);
+		}
+	}
+
+	@Nested
+	@DisplayName("getAllCommunities")
+	class GetAllCommunities {
+
+		@Test
+		@DisplayName("댓글 수를 배치로 로드하여 N+1 방지")
+		void batchLoadsCommentCounts() {
+			Community c1 = createCommunity(1L, 10L);
+			Community c2 = createCommunity(2L, 10L);
+
+			when(communityRepository.findAll()).thenReturn(List.of(c1, c2));
+			when(commentRepository.countByCommunityIds(List.of(1L, 2L)))
+				.thenReturn(Map.of(1L, 3L, 2L, 7L));
+
+			List<CommunitySummaryResponse> result = sut.getAllCommunities();
+
+			assertThat(result).hasSize(2);
+			assertThat(result.get(0).commentCount()).isEqualTo(3L);
+			assertThat(result.get(1).commentCount()).isEqualTo(7L);
+			verify(commentRepository, times(1)).countByCommunityIds(anyList());
+		}
+
+		@Test
+		@DisplayName("빈 목록이면 배치 호출하지 않음")
+		void emptyList_noBatchCall() {
+			when(communityRepository.findAll()).thenReturn(List.of());
+
+			List<CommunitySummaryResponse> result = sut.getAllCommunities();
+
+			assertThat(result).isEmpty();
+			verify(commentRepository, never()).countByCommunityIds(anyList());
+		}
+	}
+
+	// ── 헬퍼 메서드 ──
+
+	private Community createCommunity(Long id, Long writerId) {
+		Community community = Community.builder()
+			.communityId(id)
+			.title("테스트 제목")
+			.content("테스트 내용입니다. 충분히 긴 내용으로 preview 테스트도 가능합니다.")
+			.field(CommunityField.RECOMMEND)
+			.imageUrls(List.of("img1.jpg"))
+			.writerId(writerId)
+			.likeCount(0L)
+			.build();
+		ReflectionTestUtils.setField(community, "createdAt", LocalDateTime.now());
+		return community;
+	}
+
+	private User createUser(Long userId) {
+		return User.builder()
+			.userId(userId)
+			.nickName("testUser")
+			.email("test@test.com")
+			.profileImageUrl("profile.jpg")
+			.mainPlatform(Platform.YOUTUBE)
+			.activeYoutube("youtube_channel")
+			.build();
+	}
+}

--- a/src/test/java/tave/crezipsa/crezipsa/application/community/usecase/CommunityUseCaseImplTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/application/community/usecase/CommunityUseCaseImplTest.java
@@ -3,8 +3,9 @@ package tave.crezipsa.crezipsa.application.community.usecase;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static tave.crezipsa.crezipsa.fixture.CommunityFixture.*;
+import static tave.crezipsa.crezipsa.fixture.UserFixture.*;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -22,14 +23,12 @@ import tave.crezipsa.crezipsa.application.community.dto.request.CommunityUpdateR
 import tave.crezipsa.crezipsa.application.community.dto.response.CommunityDetailResponse;
 import tave.crezipsa.crezipsa.application.community.dto.response.CommunitySummaryResponse;
 import tave.crezipsa.crezipsa.domain.community.domain.Community;
-import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
 import tave.crezipsa.crezipsa.domain.community.domain.Like;
 import tave.crezipsa.crezipsa.domain.community.domain.LikeId;
 import tave.crezipsa.crezipsa.domain.community.repository.CommentRepository;
 import tave.crezipsa.crezipsa.domain.community.repository.CommunityRepository;
 import tave.crezipsa.crezipsa.domain.community.repository.LikeRepository;
 import tave.crezipsa.crezipsa.domain.user.entity.User;
-import tave.crezipsa.crezipsa.domain.user.enums.Platform;
 import tave.crezipsa.crezipsa.domain.user.repository.UserRepository;
 import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
 import tave.crezipsa.crezipsa.global.exception.model.CommonException;
@@ -58,9 +57,11 @@ class CommunityUseCaseImplTest {
 		@Test
 		@DisplayName("작성자가 아니면 UNAUTHORIZED_COMMUNITY 예외")
 		void nonWriter_throwsUnauthorized() {
+			// given
 			Community community = createCommunity(1L, 100L);
 			when(communityRepository.findById(1L)).thenReturn(Optional.of(community));
 
+			// when & then
 			assertThatThrownBy(() -> sut.updateCommunity(1L, 999L, new CommunityUpdateRequest()))
 				.isInstanceOf(CommonException.class)
 				.extracting("errorCode")
@@ -70,8 +71,10 @@ class CommunityUseCaseImplTest {
 		@Test
 		@DisplayName("존재하지 않는 게시글이면 COMMUNITY_NOT_FOUND 예외")
 		void notFound_throwsCommunityNotFound() {
+			// given
 			when(communityRepository.findById(1L)).thenReturn(Optional.empty());
 
+			// when & then
 			assertThatThrownBy(() -> sut.updateCommunity(1L, 1L, new CommunityUpdateRequest()))
 				.isInstanceOf(CommonException.class)
 				.extracting("errorCode")
@@ -81,14 +84,17 @@ class CommunityUseCaseImplTest {
 		@Test
 		@DisplayName("작성자가 맞으면 정상 업데이트")
 		void writer_updatesSuccessfully() {
+			// given
 			Community community = createCommunity(1L, 100L);
 			when(communityRepository.findById(1L)).thenReturn(Optional.of(community));
 
 			CommunityUpdateRequest request = new CommunityUpdateRequest();
 			ReflectionTestUtils.setField(request, "title", "updated title");
 
+			// when
 			var result = sut.updateCommunity(1L, 100L, request);
 
+			// then
 			assertThat(result.title()).isEqualTo("updated title");
 			assertThat(result.content()).isEqualTo("테스트 내용입니다. 충분히 긴 내용으로 preview 테스트도 가능합니다.");
 		}
@@ -101,9 +107,11 @@ class CommunityUseCaseImplTest {
 		@Test
 		@DisplayName("작성자가 아니면 UNAUTHORIZED_COMMUNITY 예외")
 		void nonWriter_throwsUnauthorized() {
+			// given
 			Community community = createCommunity(1L, 100L);
 			when(communityRepository.findById(1L)).thenReturn(Optional.of(community));
 
+			// when & then
 			assertThatThrownBy(() -> sut.deleteCommunity(999L, 1L))
 				.isInstanceOf(CommonException.class)
 				.extracting("errorCode")
@@ -113,11 +121,14 @@ class CommunityUseCaseImplTest {
 		@Test
 		@DisplayName("작성자가 맞으면 정상 삭제")
 		void writer_deletesSuccessfully() {
+			// given
 			Community community = createCommunity(1L, 100L);
 			when(communityRepository.findById(1L)).thenReturn(Optional.of(community));
 
+			// when
 			sut.deleteCommunity(100L, 1L);
 
+			// then
 			verify(communityRepository).delete(community);
 		}
 	}
@@ -129,6 +140,7 @@ class CommunityUseCaseImplTest {
 		@Test
 		@DisplayName("상세 정보를 올바르게 조합 - 다른 사용자가 좋아요한 게시글")
 		void assembliesDetailCorrectly() {
+			// given
 			Long communityId = 1L;
 			Long writerId = 10L;
 			Long viewerId = 20L;
@@ -143,8 +155,10 @@ class CommunityUseCaseImplTest {
 			when(commentUsecase.getComments(communityId, viewerId)).thenReturn(List.of());
 			when(likeRepository.findById(new LikeId(viewerId, communityId))).thenReturn(Optional.of(like));
 
+			// when
 			CommunityDetailResponse result = sut.getCommunity(communityId, viewerId);
 
+			// then
 			assertThat(result.communityId()).isEqualTo(communityId);
 			assertThat(result.isWriter()).isFalse();
 			assertThat(result.isLiked()).isTrue();
@@ -155,6 +169,7 @@ class CommunityUseCaseImplTest {
 		@Test
 		@DisplayName("좋아요 기록 없으면 isLiked=false, 본인 게시글이면 isWriter=true")
 		void noLike_isLikedFalse_ownPost_isWriterTrue() {
+			// given
 			Long communityId = 1L;
 			Long writerId = 10L;
 
@@ -167,8 +182,10 @@ class CommunityUseCaseImplTest {
 			when(commentUsecase.getComments(communityId, writerId)).thenReturn(List.of());
 			when(likeRepository.findById(any(LikeId.class))).thenReturn(Optional.empty());
 
+			// when
 			CommunityDetailResponse result = sut.getCommunity(communityId, writerId);
 
+			// then
 			assertThat(result.isLiked()).isFalse();
 			assertThat(result.isWriter()).isTrue();
 		}
@@ -181,6 +198,7 @@ class CommunityUseCaseImplTest {
 		@Test
 		@DisplayName("null 키워드면 SEARCH_KEYWORD_REQUIRED 예외")
 		void nullKeyword_throws() {
+			// when & then
 			assertThatThrownBy(() -> sut.searchCommunities(null, null, "latest", 0, 10))
 				.isInstanceOf(CommonException.class)
 				.extracting("errorCode")
@@ -190,6 +208,7 @@ class CommunityUseCaseImplTest {
 		@Test
 		@DisplayName("빈 키워드면 SEARCH_KEYWORD_REQUIRED 예외")
 		void blankKeyword_throws() {
+			// when & then
 			assertThatThrownBy(() -> sut.searchCommunities("   ", null, "latest", 0, 10))
 				.isInstanceOf(CommonException.class)
 				.extracting("errorCode")
@@ -199,8 +218,10 @@ class CommunityUseCaseImplTest {
 		@Test
 		@DisplayName("30자 초과 키워드면 SEARCH_KEYWORD_TOO_LONG 예외")
 		void tooLongKeyword_throws() {
+			// given
 			String longKeyword = "a".repeat(31);
 
+			// when & then
 			assertThatThrownBy(() -> sut.searchCommunities(longKeyword, null, "latest", 0, 10))
 				.isInstanceOf(CommonException.class)
 				.extracting("errorCode")
@@ -215,6 +236,7 @@ class CommunityUseCaseImplTest {
 		@Test
 		@DisplayName("댓글 수를 배치로 로드하여 N+1 방지")
 		void batchLoadsCommentCounts() {
+			// given
 			Community c1 = createCommunity(1L, 10L);
 			Community c2 = createCommunity(2L, 10L);
 
@@ -222,8 +244,10 @@ class CommunityUseCaseImplTest {
 			when(commentRepository.countByCommunityIds(List.of(1L, 2L)))
 				.thenReturn(Map.of(1L, 3L, 2L, 7L));
 
+			// when
 			List<CommunitySummaryResponse> result = sut.getAllCommunities();
 
+			// then
 			assertThat(result).hasSize(2);
 			assertThat(result.get(0).commentCount()).isEqualTo(3L);
 			assertThat(result.get(1).commentCount()).isEqualTo(7L);
@@ -233,39 +257,15 @@ class CommunityUseCaseImplTest {
 		@Test
 		@DisplayName("빈 목록이면 배치 호출하지 않음")
 		void emptyList_noBatchCall() {
+			// given
 			when(communityRepository.findAll()).thenReturn(List.of());
 
+			// when
 			List<CommunitySummaryResponse> result = sut.getAllCommunities();
 
+			// then
 			assertThat(result).isEmpty();
 			verify(commentRepository, never()).countByCommunityIds(anyList());
 		}
-	}
-
-	// ── 헬퍼 메서드 ──
-
-	private Community createCommunity(Long id, Long writerId) {
-		Community community = Community.builder()
-			.communityId(id)
-			.title("테스트 제목")
-			.content("테스트 내용입니다. 충분히 긴 내용으로 preview 테스트도 가능합니다.")
-			.field(CommunityField.RECOMMEND)
-			.imageUrls(List.of("img1.jpg"))
-			.writerId(writerId)
-			.likeCount(0L)
-			.build();
-		ReflectionTestUtils.setField(community, "createdAt", LocalDateTime.now());
-		return community;
-	}
-
-	private User createUser(Long userId) {
-		return User.builder()
-			.userId(userId)
-			.nickName("testUser")
-			.email("test@test.com")
-			.profileImageUrl("profile.jpg")
-			.mainPlatform(Platform.YOUTUBE)
-			.activeYoutube("youtube_channel")
-			.build();
 	}
 }

--- a/src/test/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImplTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImplTest.java
@@ -3,9 +3,8 @@ package tave.crezipsa.crezipsa.application.community.usecase;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static tave.crezipsa.crezipsa.fixture.CommunityFixture.*;
 
-import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -15,10 +14,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import tave.crezipsa.crezipsa.domain.community.domain.Community;
-import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
 import tave.crezipsa.crezipsa.domain.community.domain.Like;
 import tave.crezipsa.crezipsa.domain.community.domain.LikeId;
 import tave.crezipsa.crezipsa.domain.community.repository.CommentRepository;
@@ -47,6 +44,7 @@ class LikeUseCaseImplTest {
 		@Test
 		@DisplayName("새로운 좋아요 - Like 생성 후 커뮤니티 likeCount 증가")
 		void newLike_createsAndIncrements() {
+			// given
 			Long userId = 1L;
 			Long communityId = 10L;
 			Community community = createCommunity(communityId);
@@ -54,8 +52,10 @@ class LikeUseCaseImplTest {
 			when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
 			when(likeRepository.findById(new LikeId(userId, communityId))).thenReturn(Optional.empty());
 
+			// when
 			sut.like(userId, communityId);
 
+			// then
 			verify(likeRepository).save(any(Like.class));
 			assertThat(community.getLikeCount()).isEqualTo(1L);
 		}
@@ -63,6 +63,7 @@ class LikeUseCaseImplTest {
 		@Test
 		@DisplayName("이미 좋아요 상태 - unlike으로 토글, likeCount 감소")
 		void existingLiked_togglesOff() {
+			// given
 			Long userId = 1L;
 			Long communityId = 10L;
 			Community community = createCommunity(communityId);
@@ -73,8 +74,10 @@ class LikeUseCaseImplTest {
 			when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
 			when(likeRepository.findById(new LikeId(userId, communityId))).thenReturn(Optional.of(existingLike));
 
+			// when
 			sut.like(userId, communityId);
 
+			// then
 			assertThat(existingLike.isLiked()).isFalse();
 			assertThat(community.getLikeCount()).isZero();
 			verify(likeRepository, never()).save(any());
@@ -83,6 +86,7 @@ class LikeUseCaseImplTest {
 		@Test
 		@DisplayName("좋아요 취소 상태에서 다시 좋아요 - like으로 토글, likeCount 증가")
 		void existingUnliked_togglesOn() {
+			// given
 			Long userId = 1L;
 			Long communityId = 10L;
 			Community community = createCommunity(communityId);
@@ -93,8 +97,10 @@ class LikeUseCaseImplTest {
 			when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
 			when(likeRepository.findById(new LikeId(userId, communityId))).thenReturn(Optional.of(existingLike));
 
+			// when
 			sut.like(userId, communityId);
 
+			// then
 			assertThat(existingLike.isLiked()).isTrue();
 			assertThat(community.getLikeCount()).isEqualTo(1L);
 		}
@@ -102,8 +108,10 @@ class LikeUseCaseImplTest {
 		@Test
 		@DisplayName("존재하지 않는 게시글이면 COMMUNITY_NOT_FOUND 예외")
 		void communityNotFound_throws() {
+			// given
 			when(communityRepository.findById(999L)).thenReturn(Optional.empty());
 
+			// when & then
 			assertThatThrownBy(() -> sut.like(1L, 999L))
 				.isInstanceOf(CommonException.class)
 				.extracting("errorCode")
@@ -118,6 +126,7 @@ class LikeUseCaseImplTest {
 		@Test
 		@DisplayName("좋아요 기록이 없으면 NOT_LIKED 예외")
 		void noLikeRecord_throwsNotLiked() {
+			// given
 			Long userId = 1L;
 			Long communityId = 10L;
 			Community community = createCommunity(communityId);
@@ -125,6 +134,7 @@ class LikeUseCaseImplTest {
 			when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
 			when(likeRepository.findById(new LikeId(userId, communityId))).thenReturn(Optional.empty());
 
+			// when & then
 			assertThatThrownBy(() -> sut.unlike(userId, communityId))
 				.isInstanceOf(CommonException.class)
 				.extracting("errorCode")
@@ -134,6 +144,7 @@ class LikeUseCaseImplTest {
 		@Test
 		@DisplayName("이미 unlike 상태면 NOT_LIKED 예외")
 		void alreadyUnliked_throwsNotLiked() {
+			// given
 			Long userId = 1L;
 			Long communityId = 10L;
 			Community community = createCommunity(communityId);
@@ -144,6 +155,7 @@ class LikeUseCaseImplTest {
 			when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
 			when(likeRepository.findById(new LikeId(userId, communityId))).thenReturn(Optional.of(existingLike));
 
+			// when & then
 			assertThatThrownBy(() -> sut.unlike(userId, communityId))
 				.isInstanceOf(CommonException.class)
 				.extracting("errorCode")
@@ -153,6 +165,7 @@ class LikeUseCaseImplTest {
 		@Test
 		@DisplayName("정상 unlike - isLiked=false로 변경, likeCount 감소")
 		void liked_decrementsCount() {
+			// given
 			Long userId = 1L;
 			Long communityId = 10L;
 			Community community = createCommunity(communityId);
@@ -163,8 +176,10 @@ class LikeUseCaseImplTest {
 			when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
 			when(likeRepository.findById(new LikeId(userId, communityId))).thenReturn(Optional.of(existingLike));
 
+			// when
 			sut.unlike(userId, communityId);
 
+			// then
 			assertThat(existingLike.isLiked()).isFalse();
 			assertThat(community.getLikeCount()).isZero();
 		}
@@ -177,27 +192,14 @@ class LikeUseCaseImplTest {
 		@Test
 		@DisplayName("리포지토리에서 조회한 좋아요 수 반환")
 		void returnsCountFromRepository() {
+			// given
 			when(likeRepository.countByCommunityIdAndIsLikedTrue(10L)).thenReturn(42L);
 
+			// when
 			long result = sut.getLikeCount(10L);
 
+			// then
 			assertThat(result).isEqualTo(42L);
 		}
-	}
-
-	// ── 헬퍼 메서드 ──
-
-	private Community createCommunity(Long id) {
-		Community community = Community.builder()
-			.communityId(id)
-			.title("test")
-			.content("content content content content content content content")
-			.field(CommunityField.RECOMMEND)
-			.imageUrls(List.of())
-			.writerId(1L)
-			.likeCount(0L)
-			.build();
-		ReflectionTestUtils.setField(community, "createdAt", LocalDateTime.now());
-		return community;
 	}
 }

--- a/src/test/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImplTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImplTest.java
@@ -1,0 +1,203 @@
+package tave.crezipsa.crezipsa.application.community.usecase;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import tave.crezipsa.crezipsa.domain.community.domain.Community;
+import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
+import tave.crezipsa.crezipsa.domain.community.domain.Like;
+import tave.crezipsa.crezipsa.domain.community.domain.LikeId;
+import tave.crezipsa.crezipsa.domain.community.repository.CommentRepository;
+import tave.crezipsa.crezipsa.domain.community.repository.CommunityRepository;
+import tave.crezipsa.crezipsa.domain.community.repository.LikeRepository;
+import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
+import tave.crezipsa.crezipsa.global.exception.model.CommonException;
+
+@ExtendWith(MockitoExtension.class)
+class LikeUseCaseImplTest {
+
+	@Mock
+	private LikeRepository likeRepository;
+	@Mock
+	private CommunityRepository communityRepository;
+	@Mock
+	private CommentRepository commentRepository;
+
+	@InjectMocks
+	private LikeUseCaseImpl sut;
+
+	@Nested
+	@DisplayName("like")
+	class LikeAction {
+
+		@Test
+		@DisplayName("새로운 좋아요 - Like 생성 후 커뮤니티 likeCount 증가")
+		void newLike_createsAndIncrements() {
+			Long userId = 1L;
+			Long communityId = 10L;
+			Community community = createCommunity(communityId);
+
+			when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
+			when(likeRepository.findById(new LikeId(userId, communityId))).thenReturn(Optional.empty());
+
+			sut.like(userId, communityId);
+
+			verify(likeRepository).save(any(Like.class));
+			assertThat(community.getLikeCount()).isEqualTo(1L);
+		}
+
+		@Test
+		@DisplayName("이미 좋아요 상태 - unlike으로 토글, likeCount 감소")
+		void existingLiked_togglesOff() {
+			Long userId = 1L;
+			Long communityId = 10L;
+			Community community = createCommunity(communityId);
+			community.increaseLikeCount();
+
+			Like existingLike = Like.of(userId, communityId);
+
+			when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
+			when(likeRepository.findById(new LikeId(userId, communityId))).thenReturn(Optional.of(existingLike));
+
+			sut.like(userId, communityId);
+
+			assertThat(existingLike.isLiked()).isFalse();
+			assertThat(community.getLikeCount()).isZero();
+			verify(likeRepository, never()).save(any());
+		}
+
+		@Test
+		@DisplayName("좋아요 취소 상태에서 다시 좋아요 - like으로 토글, likeCount 증가")
+		void existingUnliked_togglesOn() {
+			Long userId = 1L;
+			Long communityId = 10L;
+			Community community = createCommunity(communityId);
+
+			Like existingLike = Like.of(userId, communityId);
+			existingLike.unlike();
+
+			when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
+			when(likeRepository.findById(new LikeId(userId, communityId))).thenReturn(Optional.of(existingLike));
+
+			sut.like(userId, communityId);
+
+			assertThat(existingLike.isLiked()).isTrue();
+			assertThat(community.getLikeCount()).isEqualTo(1L);
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 게시글이면 COMMUNITY_NOT_FOUND 예외")
+		void communityNotFound_throws() {
+			when(communityRepository.findById(999L)).thenReturn(Optional.empty());
+
+			assertThatThrownBy(() -> sut.like(1L, 999L))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.COMMUNITY_NOT_FOUND);
+		}
+	}
+
+	@Nested
+	@DisplayName("unlike")
+	class UnlikeAction {
+
+		@Test
+		@DisplayName("좋아요 기록이 없으면 NOT_LIKED 예외")
+		void noLikeRecord_throwsNotLiked() {
+			Long userId = 1L;
+			Long communityId = 10L;
+			Community community = createCommunity(communityId);
+
+			when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
+			when(likeRepository.findById(new LikeId(userId, communityId))).thenReturn(Optional.empty());
+
+			assertThatThrownBy(() -> sut.unlike(userId, communityId))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.NOT_LIKED);
+		}
+
+		@Test
+		@DisplayName("이미 unlike 상태면 NOT_LIKED 예외")
+		void alreadyUnliked_throwsNotLiked() {
+			Long userId = 1L;
+			Long communityId = 10L;
+			Community community = createCommunity(communityId);
+
+			Like existingLike = Like.of(userId, communityId);
+			existingLike.unlike();
+
+			when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
+			when(likeRepository.findById(new LikeId(userId, communityId))).thenReturn(Optional.of(existingLike));
+
+			assertThatThrownBy(() -> sut.unlike(userId, communityId))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.NOT_LIKED);
+		}
+
+		@Test
+		@DisplayName("정상 unlike - isLiked=false로 변경, likeCount 감소")
+		void liked_decrementsCount() {
+			Long userId = 1L;
+			Long communityId = 10L;
+			Community community = createCommunity(communityId);
+			community.increaseLikeCount();
+
+			Like existingLike = Like.of(userId, communityId);
+
+			when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
+			when(likeRepository.findById(new LikeId(userId, communityId))).thenReturn(Optional.of(existingLike));
+
+			sut.unlike(userId, communityId);
+
+			assertThat(existingLike.isLiked()).isFalse();
+			assertThat(community.getLikeCount()).isZero();
+		}
+	}
+
+	@Nested
+	@DisplayName("getLikeCount")
+	class GetLikeCount {
+
+		@Test
+		@DisplayName("리포지토리에서 조회한 좋아요 수 반환")
+		void returnsCountFromRepository() {
+			when(likeRepository.countByCommunityIdAndIsLikedTrue(10L)).thenReturn(42L);
+
+			long result = sut.getLikeCount(10L);
+
+			assertThat(result).isEqualTo(42L);
+		}
+	}
+
+	// ── 헬퍼 메서드 ──
+
+	private Community createCommunity(Long id) {
+		Community community = Community.builder()
+			.communityId(id)
+			.title("test")
+			.content("content content content content content content content")
+			.field(CommunityField.RECOMMEND)
+			.imageUrls(List.of())
+			.writerId(1L)
+			.likeCount(0L)
+			.build();
+		ReflectionTestUtils.setField(community, "createdAt", LocalDateTime.now());
+		return community;
+	}
+}

--- a/src/test/java/tave/crezipsa/crezipsa/application/storyboard/usecase/StoryboardUsecaseImplTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/application/storyboard/usecase/StoryboardUsecaseImplTest.java
@@ -1,0 +1,126 @@
+package tave.crezipsa.crezipsa.application.storyboard.usecase;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static tave.crezipsa.crezipsa.fixture.ChatFixture.*;
+import static tave.crezipsa.crezipsa.fixture.StoryboardFixture.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import tave.crezipsa.crezipsa.application.storyboard.dto.request.CreateStoryboardRequest;
+import tave.crezipsa.crezipsa.application.storyboard.dto.response.StoryboardEditorResponse;
+import tave.crezipsa.crezipsa.domain.chat.entity.ChatMessage;
+import tave.crezipsa.crezipsa.domain.chat.port.ChatMessageRepositoryPort;
+import tave.crezipsa.crezipsa.domain.storyboard.entity.Storyboard;
+import tave.crezipsa.crezipsa.domain.storyboard.entity.StoryboardCut;
+import tave.crezipsa.crezipsa.domain.storyboard.port.StoryboardCutRepositoryPort;
+import tave.crezipsa.crezipsa.domain.storyboard.port.StoryboardRepositoryPort;
+import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
+import tave.crezipsa.crezipsa.global.exception.model.CommonException;
+
+@ExtendWith(MockitoExtension.class)
+class StoryboardUsecaseImplTest {
+
+	@Mock
+	private StoryboardRepositoryPort storyboardRepository;
+	@Mock
+	private StoryboardCutRepositoryPort storyboardCutRepository;
+	@Mock
+	private ChatMessageRepositoryPort chatMessageRepository;
+
+	@InjectMocks
+	private StoryboardUsecaseImpl sut;
+
+	@Nested
+	@DisplayName("create")
+	class Create {
+
+		@Test
+		@DisplayName("chatMessageId가 null이면 검증 없이 스토리보드 생성")
+		void noChatMessage_createsSuccessfully() {
+			// given
+			Long userId = 1L;
+			CreateStoryboardRequest request = new CreateStoryboardRequest("제목", null);
+
+			Storyboard saved = createStoryboard(10L, userId);
+			StoryboardCut firstCut = createStoryboardCut(100L, 10L, 0);
+
+			when(storyboardRepository.save(any(Storyboard.class))).thenReturn(saved);
+			when(storyboardCutRepository.findNextOrder(10L)).thenReturn(0);
+			when(storyboardCutRepository.save(any(StoryboardCut.class))).thenReturn(firstCut);
+
+			// when
+			StoryboardEditorResponse result = sut.create(userId, request);
+
+			// then
+			assertThat(result.storyboardId()).isEqualTo(10L);
+			assertThat(result.cuts()).hasSize(1);
+			verify(chatMessageRepository, never()).findById(anyLong());
+		}
+
+		@Test
+		@DisplayName("chatMessageId가 존재하지 않으면 CHAT_NOT_FOUND 예외")
+		void chatMessageNotFound_throws() {
+			// given
+			Long userId = 1L;
+			CreateStoryboardRequest request = new CreateStoryboardRequest("제목", 999L);
+
+			when(chatMessageRepository.findById(999L)).thenReturn(null);
+
+			// when & then
+			assertThatThrownBy(() -> sut.create(userId, request))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.CHAT_NOT_FOUND);
+		}
+
+		@Test
+		@DisplayName("chatMessage의 senderType이 AI가 아니면 INVALID_SENDER_TYPE 예외")
+		void userSenderType_throws() {
+			// given
+			Long userId = 1L;
+			CreateStoryboardRequest request = new CreateStoryboardRequest("제목", 50L);
+
+			ChatMessage userMessage = createUserMessage(50L, 1L);
+			when(chatMessageRepository.findById(50L)).thenReturn(userMessage);
+
+			// when & then
+			assertThatThrownBy(() -> sut.create(userId, request))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.INVALID_SENDER_TYPE);
+		}
+
+		@Test
+		@DisplayName("AI 메시지로부터 스토리보드 정상 생성")
+		void fromAiMessage_createsSuccessfully() {
+			// given
+			Long userId = 1L;
+			CreateStoryboardRequest request = new CreateStoryboardRequest("제목", 50L);
+
+			ChatMessage aiMessage = createAiMessage(50L, 1L);
+			Storyboard saved = createStoryboard(10L, userId, 50L);
+			StoryboardCut firstCut = createStoryboardCut(100L, 10L, 0);
+
+			when(chatMessageRepository.findById(50L)).thenReturn(aiMessage);
+			when(storyboardRepository.save(any(Storyboard.class))).thenReturn(saved);
+			when(storyboardCutRepository.findNextOrder(10L)).thenReturn(0);
+			when(storyboardCutRepository.save(any(StoryboardCut.class))).thenReturn(firstCut);
+
+			// when
+			StoryboardEditorResponse result = sut.create(userId, request);
+
+			// then
+			assertThat(result.storyboardId()).isEqualTo(10L);
+			assertThat(result.sourceChatMessageId()).isEqualTo(50L);
+			assertThat(result.cuts()).hasSize(1);
+		}
+	}
+}

--- a/src/test/java/tave/crezipsa/crezipsa/application/storyboard/usecase/StoryboardUsecaseImplTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/application/storyboard/usecase/StoryboardUsecaseImplTest.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.*;
 import static tave.crezipsa.crezipsa.fixture.ChatFixture.*;
 import static tave.crezipsa.crezipsa.fixture.StoryboardFixture.*;
 
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -121,6 +123,61 @@ class StoryboardUsecaseImplTest {
 			assertThat(result.storyboardId()).isEqualTo(10L);
 			assertThat(result.sourceChatMessageId()).isEqualTo(50L);
 			assertThat(result.cuts()).hasSize(1);
+		}
+	}
+
+	@Nested
+	@DisplayName("get")
+	class Get {
+
+		@Test
+		@DisplayName("스토리보드가 없으면 STORYBOARD_NOT_FOUND 예외")
+		void notFound_throws() {
+			// given
+			when(storyboardRepository.findById(1L)).thenReturn(null);
+
+			// when & then
+			assertThatThrownBy(() -> sut.get(1L, 1L))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.STORYBOARD_NOT_FOUND);
+		}
+
+		@Test
+		@DisplayName("다른 사용자의 스토리보드면 STORYBOARD_NOT_FOUND 예외")
+		void otherUser_throws() {
+			// given
+			Storyboard sb = createStoryboard(1L, 100L);
+			when(storyboardRepository.findById(1L)).thenReturn(sb);
+
+			// when & then
+			assertThatThrownBy(() -> sut.get(999L, 1L))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.STORYBOARD_NOT_FOUND);
+		}
+
+		@Test
+		@DisplayName("본인 스토리보드면 컷 목록과 함께 정상 반환")
+		void owner_returnsWithCuts() {
+			// given
+			Long userId = 1L;
+			Long storyboardId = 10L;
+			Storyboard sb = createStoryboard(storyboardId, userId);
+			StoryboardCut cut1 = createStoryboardCut(100L, storyboardId, 0);
+			StoryboardCut cut2 = createStoryboardCut(101L, storyboardId, 1);
+
+			when(storyboardRepository.findById(storyboardId)).thenReturn(sb);
+			when(storyboardCutRepository.findByStoryboardId(storyboardId)).thenReturn(List.of(cut1, cut2));
+
+			// when
+			StoryboardEditorResponse result = sut.get(userId, storyboardId);
+
+			// then
+			assertThat(result.storyboardId()).isEqualTo(storyboardId);
+			assertThat(result.cuts()).hasSize(2);
+			assertThat(result.cuts().get(0).cutId()).isEqualTo(100L);
+			assertThat(result.cuts().get(1).cutId()).isEqualTo(101L);
 		}
 	}
 }

--- a/src/test/java/tave/crezipsa/crezipsa/application/storyboard/usecase/StoryboardUsecaseImplTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/application/storyboard/usecase/StoryboardUsecaseImplTest.java
@@ -433,4 +433,72 @@ class StoryboardUsecaseImplTest {
 			assertThat(result.etc()).isEqualTo("새 기타");
 		}
 	}
+
+	@Nested
+	@DisplayName("deleteCut")
+	class DeleteCut {
+
+		@Test
+		@DisplayName("컷이 없으면 STORYBOARD_CUT_NOT_FOUND 예외")
+		void cutNotFound_throws() {
+			// given
+			when(storyboardCutRepository.findById(1L)).thenReturn(null);
+
+			// when & then
+			assertThatThrownBy(() -> sut.deleteCut(1L, 1L))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.STORYBOARD_CUT_NOT_FOUND);
+		}
+
+		@Test
+		@DisplayName("스토리보드가 없으면 STORYBOARD_NOT_FOUND 예외")
+		void storyboardNotFound_throws() {
+			// given
+			StoryboardCut cut = createStoryboardCut(1L, 10L, 0);
+			when(storyboardCutRepository.findById(1L)).thenReturn(cut);
+			when(storyboardRepository.findById(10L)).thenReturn(null);
+
+			// when & then
+			assertThatThrownBy(() -> sut.deleteCut(1L, 1L))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.STORYBOARD_NOT_FOUND);
+		}
+
+		@Test
+		@DisplayName("다른 사용자면 STORYBOARD_NOT_FOUND 예외")
+		void otherUser_throws() {
+			// given
+			StoryboardCut cut = createStoryboardCut(1L, 10L, 0);
+			Storyboard sb = createStoryboard(10L, 100L);
+
+			when(storyboardCutRepository.findById(1L)).thenReturn(cut);
+			when(storyboardRepository.findById(10L)).thenReturn(sb);
+
+			// when & then
+			assertThatThrownBy(() -> sut.deleteCut(999L, 1L))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.STORYBOARD_NOT_FOUND);
+		}
+
+		@Test
+		@DisplayName("본인 컷이면 삭제 성공")
+		void owner_deletesCut() {
+			// given
+			Long userId = 1L;
+			StoryboardCut cut = createStoryboardCut(1L, 10L, 0);
+			Storyboard sb = createStoryboard(10L, userId);
+
+			when(storyboardCutRepository.findById(1L)).thenReturn(cut);
+			when(storyboardRepository.findById(10L)).thenReturn(sb);
+
+			// when
+			sut.deleteCut(userId, 1L);
+
+			// then
+			verify(storyboardCutRepository).deleteById(1L);
+		}
+	}
 }

--- a/src/test/java/tave/crezipsa/crezipsa/application/storyboard/usecase/StoryboardUsecaseImplTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/application/storyboard/usecase/StoryboardUsecaseImplTest.java
@@ -17,6 +17,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import tave.crezipsa.crezipsa.application.storyboard.dto.request.CreateStoryboardRequest;
+import tave.crezipsa.crezipsa.application.storyboard.dto.request.UpdateStoryboardCutRequest;
 import tave.crezipsa.crezipsa.application.storyboard.dto.request.UpdateStoryboardTitleRequest;
 import tave.crezipsa.crezipsa.application.storyboard.dto.response.StoryboardCutResponse;
 import tave.crezipsa.crezipsa.application.storyboard.dto.response.StoryboardEditorResponse;
@@ -345,6 +346,91 @@ class StoryboardUsecaseImplTest {
 			// then
 			assertThat(result.cutId()).isEqualTo(200L);
 			assertThat(result.order()).isEqualTo(2);
+		}
+	}
+
+	@Nested
+	@DisplayName("updateCut")
+	class UpdateCut {
+
+		@Test
+		@DisplayName("컷이 없으면 STORYBOARD_CUT_NOT_FOUND 예외")
+		void cutNotFound_throws() {
+			// given
+			when(storyboardCutRepository.findById(1L)).thenReturn(null);
+
+			// when & then
+			assertThatThrownBy(() -> sut.updateCut(1L, 1L, new UpdateStoryboardCutRequest(null, null, null, null)))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.STORYBOARD_CUT_NOT_FOUND);
+		}
+
+		@Test
+		@DisplayName("다른 사용자의 스토리보드 컷이면 STORYBOARD_NOT_FOUND 예외")
+		void otherUser_throws() {
+			// given
+			StoryboardCut cut = createStoryboardCut(1L, 10L, 0);
+			Storyboard sb = createStoryboard(10L, 100L);
+
+			when(storyboardCutRepository.findById(1L)).thenReturn(cut);
+			when(storyboardRepository.findById(10L)).thenReturn(sb);
+
+			// when & then
+			assertThatThrownBy(() -> sut.updateCut(999L, 1L, new UpdateStoryboardCutRequest(null, null, null, null)))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.STORYBOARD_NOT_FOUND);
+		}
+
+		@Test
+		@DisplayName("null 필드는 기존 값 유지, 제공된 필드만 업데이트")
+		void partialUpdate_keepsExisting() {
+			// given
+			Long userId = 1L;
+			StoryboardCut cut = createStoryboardCut(1L, 10L, 0);
+			Storyboard sb = createStoryboard(10L, userId);
+
+			when(storyboardCutRepository.findById(1L)).thenReturn(cut);
+			when(storyboardRepository.findById(10L)).thenReturn(sb);
+			when(storyboardCutRepository.save(any(StoryboardCut.class)))
+				.thenAnswer(invocation -> invocation.getArgument(0));
+
+			UpdateStoryboardCutRequest request = new UpdateStoryboardCutRequest("새 구도", null, null, null);
+
+			// when
+			StoryboardCutResponse result = sut.updateCut(userId, 1L, request);
+
+			// then
+			assertThat(result.cutComposition()).isEqualTo("새 구도");
+			assertThat(result.script()).isEqualTo("스크립트");
+			assertThat(result.caption()).isEqualTo("캡션");
+			assertThat(result.etc()).isEqualTo("기타");
+		}
+
+		@Test
+		@DisplayName("모든 필드 업데이트 성공")
+		void fullUpdate_allFieldsChanged() {
+			// given
+			Long userId = 1L;
+			StoryboardCut cut = createStoryboardCut(1L, 10L, 0);
+			Storyboard sb = createStoryboard(10L, userId);
+
+			when(storyboardCutRepository.findById(1L)).thenReturn(cut);
+			when(storyboardRepository.findById(10L)).thenReturn(sb);
+			when(storyboardCutRepository.save(any(StoryboardCut.class)))
+				.thenAnswer(invocation -> invocation.getArgument(0));
+
+			UpdateStoryboardCutRequest request = new UpdateStoryboardCutRequest("새 구도", "새 스크립트", "새 캡션", "새 기타");
+
+			// when
+			StoryboardCutResponse result = sut.updateCut(userId, 1L, request);
+
+			// then
+			assertThat(result.cutComposition()).isEqualTo("새 구도");
+			assertThat(result.script()).isEqualTo("새 스크립트");
+			assertThat(result.caption()).isEqualTo("새 캡션");
+			assertThat(result.etc()).isEqualTo("새 기타");
 		}
 	}
 }

--- a/src/test/java/tave/crezipsa/crezipsa/application/storyboard/usecase/StoryboardUsecaseImplTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/application/storyboard/usecase/StoryboardUsecaseImplTest.java
@@ -17,6 +17,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import tave.crezipsa.crezipsa.application.storyboard.dto.request.CreateStoryboardRequest;
+import tave.crezipsa.crezipsa.application.storyboard.dto.request.UpdateStoryboardTitleRequest;
 import tave.crezipsa.crezipsa.application.storyboard.dto.response.StoryboardEditorResponse;
 import tave.crezipsa.crezipsa.application.storyboard.dto.response.StoryboardSummaryResponse;
 import tave.crezipsa.crezipsa.domain.chat.entity.ChatMessage;
@@ -216,6 +217,80 @@ class StoryboardUsecaseImplTest {
 			assertThat(result).hasSize(2);
 			assertThat(result.get(0).storyboardId()).isEqualTo(10L);
 			assertThat(result.get(1).storyboardId()).isEqualTo(11L);
+		}
+	}
+
+	@Nested
+	@DisplayName("updateTitle")
+	class UpdateTitle {
+
+		@Test
+		@DisplayName("스토리보드가 없으면 STORYBOARD_NOT_FOUND 예외")
+		void notFound_throws() {
+			// given
+			when(storyboardRepository.findById(1L)).thenReturn(null);
+
+			// when & then
+			assertThatThrownBy(() -> sut.updateTitle(1L, 1L, new UpdateStoryboardTitleRequest("새 제목")))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.STORYBOARD_NOT_FOUND);
+		}
+
+		@Test
+		@DisplayName("다른 사용자면 STORYBOARD_NOT_FOUND 예외")
+		void otherUser_throws() {
+			// given
+			Storyboard sb = createStoryboard(1L, 100L);
+			when(storyboardRepository.findById(1L)).thenReturn(sb);
+
+			// when & then
+			assertThatThrownBy(() -> sut.updateTitle(999L, 1L, new UpdateStoryboardTitleRequest("새 제목")))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.STORYBOARD_NOT_FOUND);
+		}
+
+		@Test
+		@DisplayName("제목이 null이면 INVALID_INPUT_VALUE 예외")
+		void nullTitle_throws() {
+			// given
+			Storyboard sb = createStoryboard(1L, 1L);
+			when(storyboardRepository.findById(1L)).thenReturn(sb);
+
+			// when & then
+			assertThatThrownBy(() -> sut.updateTitle(1L, 1L, new UpdateStoryboardTitleRequest(null)))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
+		}
+
+		@Test
+		@DisplayName("제목이 빈 문자열이면 INVALID_INPUT_VALUE 예외")
+		void blankTitle_throws() {
+			// given
+			Storyboard sb = createStoryboard(1L, 1L);
+			when(storyboardRepository.findById(1L)).thenReturn(sb);
+
+			// when & then
+			assertThatThrownBy(() -> sut.updateTitle(1L, 1L, new UpdateStoryboardTitleRequest("   ")))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
+		}
+
+		@Test
+		@DisplayName("정상 제목이면 업데이트 성공")
+		void validTitle_updates() {
+			// given
+			Storyboard sb = createStoryboard(1L, 1L);
+			when(storyboardRepository.findById(1L)).thenReturn(sb);
+
+			// when
+			sut.updateTitle(1L, 1L, new UpdateStoryboardTitleRequest("새 제목"));
+
+			// then
+			verify(storyboardRepository).save(any(Storyboard.class));
 		}
 	}
 }

--- a/src/test/java/tave/crezipsa/crezipsa/application/storyboard/usecase/StoryboardUsecaseImplTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/application/storyboard/usecase/StoryboardUsecaseImplTest.java
@@ -384,6 +384,22 @@ class StoryboardUsecaseImplTest {
 		}
 
 		@Test
+		@DisplayName("컷의 스토리보드가 존재하지 않으면 STORYBOARD_NOT_FOUND 예외")
+		void storyboardNull_throws() {
+			// given
+			StoryboardCut cut = createStoryboardCut(1L, 10L, 0);
+
+			when(storyboardCutRepository.findById(1L)).thenReturn(cut);
+			when(storyboardRepository.findById(10L)).thenReturn(null);
+
+			// when & then
+			assertThatThrownBy(() -> sut.updateCut(1L, 1L, new UpdateStoryboardCutRequest(null, null, null, null)))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.STORYBOARD_NOT_FOUND);
+		}
+
+		@Test
 		@DisplayName("null 필드는 기존 값 유지, 제공된 필드만 업데이트")
 		void partialUpdate_keepsExisting() {
 			// given
@@ -396,13 +412,13 @@ class StoryboardUsecaseImplTest {
 			when(storyboardCutRepository.save(any(StoryboardCut.class)))
 				.thenAnswer(invocation -> invocation.getArgument(0));
 
-			UpdateStoryboardCutRequest request = new UpdateStoryboardCutRequest("새 구도", null, null, null);
+			UpdateStoryboardCutRequest request = new UpdateStoryboardCutRequest(null, null, null, null);
 
 			// when
 			StoryboardCutResponse result = sut.updateCut(userId, 1L, request);
 
 			// then
-			assertThat(result.cutComposition()).isEqualTo("새 구도");
+			assertThat(result.cutComposition()).isEqualTo("컷 구도");
 			assertThat(result.script()).isEqualTo("스크립트");
 			assertThat(result.caption()).isEqualTo("캡션");
 			assertThat(result.etc()).isEqualTo("기타");

--- a/src/test/java/tave/crezipsa/crezipsa/application/storyboard/usecase/StoryboardUsecaseImplTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/application/storyboard/usecase/StoryboardUsecaseImplTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import tave.crezipsa.crezipsa.application.storyboard.dto.request.CreateStoryboardRequest;
 import tave.crezipsa.crezipsa.application.storyboard.dto.response.StoryboardEditorResponse;
+import tave.crezipsa.crezipsa.application.storyboard.dto.response.StoryboardSummaryResponse;
 import tave.crezipsa.crezipsa.domain.chat.entity.ChatMessage;
 import tave.crezipsa.crezipsa.domain.chat.port.ChatMessageRepositoryPort;
 import tave.crezipsa.crezipsa.domain.storyboard.entity.Storyboard;
@@ -178,6 +179,43 @@ class StoryboardUsecaseImplTest {
 			assertThat(result.cuts()).hasSize(2);
 			assertThat(result.cuts().get(0).cutId()).isEqualTo(100L);
 			assertThat(result.cuts().get(1).cutId()).isEqualTo(101L);
+		}
+	}
+
+	@Nested
+	@DisplayName("getMyList")
+	class GetMyList {
+
+		@Test
+		@DisplayName("스토리보드가 없으면 빈 목록 반환")
+		void noStoryboards_returnsEmpty() {
+			// given
+			when(storyboardRepository.findByUserId(1L)).thenReturn(List.of());
+
+			// when
+			List<StoryboardSummaryResponse> result = sut.getMyList(1L);
+
+			// then
+			assertThat(result).isEmpty();
+		}
+
+		@Test
+		@DisplayName("스토리보드 목록 정상 반환")
+		void hasStoryboards_returnsList() {
+			// given
+			Long userId = 1L;
+			Storyboard sb1 = createStoryboard(10L, userId);
+			Storyboard sb2 = createStoryboard(11L, userId);
+
+			when(storyboardRepository.findByUserId(userId)).thenReturn(List.of(sb1, sb2));
+
+			// when
+			List<StoryboardSummaryResponse> result = sut.getMyList(userId);
+
+			// then
+			assertThat(result).hasSize(2);
+			assertThat(result.get(0).storyboardId()).isEqualTo(10L);
+			assertThat(result.get(1).storyboardId()).isEqualTo(11L);
 		}
 	}
 }

--- a/src/test/java/tave/crezipsa/crezipsa/application/storyboard/usecase/StoryboardUsecaseImplTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/application/storyboard/usecase/StoryboardUsecaseImplTest.java
@@ -501,4 +501,51 @@ class StoryboardUsecaseImplTest {
 			verify(storyboardCutRepository).deleteById(1L);
 		}
 	}
+
+	@Nested
+	@DisplayName("deleteStoryboard")
+	class DeleteStoryboard {
+
+		@Test
+		@DisplayName("스토리보드가 없으면 STORYBOARD_NOT_FOUND 예외")
+		void notFound_throws() {
+			// given
+			when(storyboardRepository.findById(1L)).thenReturn(null);
+
+			// when & then
+			assertThatThrownBy(() -> sut.deleteStoryboard(1L, 1L))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.STORYBOARD_NOT_FOUND);
+		}
+
+		@Test
+		@DisplayName("다른 사용자면 STORYBOARD_NOT_FOUND 예외")
+		void otherUser_throws() {
+			// given
+			Storyboard sb = createStoryboard(1L, 100L);
+			when(storyboardRepository.findById(1L)).thenReturn(sb);
+
+			// when & then
+			assertThatThrownBy(() -> sut.deleteStoryboard(999L, 1L))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.STORYBOARD_NOT_FOUND);
+		}
+
+		@Test
+		@DisplayName("본인 스토리보드면 삭제 성공")
+		void owner_deletes() {
+			// given
+			Long userId = 1L;
+			Storyboard sb = createStoryboard(1L, userId);
+			when(storyboardRepository.findById(1L)).thenReturn(sb);
+
+			// when
+			sut.deleteStoryboard(userId, 1L);
+
+			// then
+			verify(storyboardRepository).deleteById(1L);
+		}
+	}
 }

--- a/src/test/java/tave/crezipsa/crezipsa/application/storyboard/usecase/StoryboardUsecaseImplTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/application/storyboard/usecase/StoryboardUsecaseImplTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import tave.crezipsa.crezipsa.application.storyboard.dto.request.CreateStoryboardRequest;
 import tave.crezipsa.crezipsa.application.storyboard.dto.request.UpdateStoryboardTitleRequest;
+import tave.crezipsa.crezipsa.application.storyboard.dto.response.StoryboardCutResponse;
 import tave.crezipsa.crezipsa.application.storyboard.dto.response.StoryboardEditorResponse;
 import tave.crezipsa.crezipsa.application.storyboard.dto.response.StoryboardSummaryResponse;
 import tave.crezipsa.crezipsa.domain.chat.entity.ChatMessage;
@@ -291,6 +292,59 @@ class StoryboardUsecaseImplTest {
 
 			// then
 			verify(storyboardRepository).save(any(Storyboard.class));
+		}
+	}
+
+	@Nested
+	@DisplayName("addCut")
+	class AddCut {
+
+		@Test
+		@DisplayName("스토리보드가 없으면 STORYBOARD_NOT_FOUND 예외")
+		void notFound_throws() {
+			// given
+			when(storyboardRepository.findById(1L)).thenReturn(null);
+
+			// when & then
+			assertThatThrownBy(() -> sut.addCut(1L, 1L))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.STORYBOARD_NOT_FOUND);
+		}
+
+		@Test
+		@DisplayName("다른 사용자면 STORYBOARD_NOT_FOUND 예외")
+		void otherUser_throws() {
+			// given
+			Storyboard sb = createStoryboard(1L, 100L);
+			when(storyboardRepository.findById(1L)).thenReturn(sb);
+
+			// when & then
+			assertThatThrownBy(() -> sut.addCut(999L, 1L))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.STORYBOARD_NOT_FOUND);
+		}
+
+		@Test
+		@DisplayName("본인 스토리보드면 컷 추가 성공")
+		void owner_addsCut() {
+			// given
+			Long userId = 1L;
+			Long storyboardId = 10L;
+			Storyboard sb = createStoryboard(storyboardId, userId);
+			StoryboardCut newCut = createStoryboardCut(200L, storyboardId, 2);
+
+			when(storyboardRepository.findById(storyboardId)).thenReturn(sb);
+			when(storyboardCutRepository.findNextOrder(storyboardId)).thenReturn(2);
+			when(storyboardCutRepository.save(any(StoryboardCut.class))).thenReturn(newCut);
+
+			// when
+			StoryboardCutResponse result = sut.addCut(userId, storyboardId);
+
+			// then
+			assertThat(result.cutId()).isEqualTo(200L);
+			assertThat(result.order()).isEqualTo(2);
 		}
 	}
 }

--- a/src/test/java/tave/crezipsa/crezipsa/domain/community/domain/CommunityDomainTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/domain/community/domain/CommunityDomainTest.java
@@ -1,0 +1,205 @@
+package tave.crezipsa.crezipsa.domain.community.domain;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
+import tave.crezipsa.crezipsa.global.exception.model.CommonException;
+
+class CommunityDomainTest {
+
+	@Nested
+	@DisplayName("Community.create")
+	class Create {
+
+		@Test
+		@DisplayName("TIP 필드에 이미지 없으면 INVALID_TIP_UPLOAD 예외")
+		void tipFieldWithoutImages_throws() {
+			assertThatThrownBy(() ->
+				Community.create("title", "content", CommunityField.TIP, null, 1L)
+			)
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.INVALID_TIP_UPLOAD);
+		}
+
+		@Test
+		@DisplayName("TIP 필드에 빈 이미지 목록이면 INVALID_TIP_UPLOAD 예외")
+		void tipFieldWithEmptyImages_throws() {
+			assertThatThrownBy(() ->
+				Community.create("title", "content", CommunityField.TIP, List.of(), 1L)
+			)
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.INVALID_TIP_UPLOAD);
+		}
+
+		@Test
+		@DisplayName("TIP 필드에 이미지 있으면 정상 생성")
+		void tipFieldWithImages_succeeds() {
+			Community community = Community.create("title", "content", CommunityField.TIP, List.of("img.jpg"), 1L);
+
+			assertThat(community.getField()).isEqualTo(CommunityField.TIP);
+			assertThat(community.getImageUrls()).containsExactly("img.jpg");
+			assertThat(community.getLikeCount()).isZero();
+		}
+
+		@Test
+		@DisplayName("null 필드면 INVALID_FIELD_TYPE 예외")
+		void nullField_throwsInvalidFieldType() {
+			assertThatThrownBy(() ->
+				Community.create("title", "content", null, null, 1L)
+			)
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.INVALID_FIELD_TYPE);
+		}
+
+		@Test
+		@DisplayName("RECOMMEND 필드는 이미지 없이 생성 가능")
+		void recommendFieldWithoutImages_succeeds() {
+			Community community = Community.create("title", "content", CommunityField.RECOMMEND, null, 1L);
+
+			assertThat(community.getImageUrls()).isEmpty();
+			assertThat(community.getLikeCount()).isZero();
+			assertThat(community.getWriterId()).isEqualTo(1L);
+		}
+	}
+
+	@Nested
+	@DisplayName("Community 좋아요 카운트")
+	class LikeCount {
+
+		@Test
+		@DisplayName("좋아요 증가")
+		void increase() {
+			Community community = Community.create("t", "c", CommunityField.RECOMMEND, null, 1L);
+			community.increaseLikeCount();
+			community.increaseLikeCount();
+
+			assertThat(community.getLikeCount()).isEqualTo(2L);
+		}
+
+		@Test
+		@DisplayName("좋아요 감소 시 0 이하로 내려가지 않음")
+		void decreaseFloorAtZero() {
+			Community community = Community.create("t", "c", CommunityField.RECOMMEND, null, 1L);
+			community.decreaseLikeCount();
+
+			assertThat(community.getLikeCount()).isZero();
+		}
+	}
+
+	@Nested
+	@DisplayName("Community.update")
+	class Update {
+
+		@Test
+		@DisplayName("null 필드는 업데이트하지 않음 (선택적 업데이트)")
+		void selectiveUpdate() {
+			Community community = Community.create("title", "content", CommunityField.RECOMMEND, null, 1L);
+			community.update("new title", null, null);
+
+			assertThat(community.getTitle()).isEqualTo("new title");
+			assertThat(community.getContent()).isEqualTo("content");
+		}
+
+		@Test
+		@DisplayName("TIP 필드 커뮤니티에서 이미지를 빈 목록으로 업데이트하면 예외")
+		void updateTipCommunityWithEmptyImages_throws() {
+			Community community = Community.create("title", "content", CommunityField.TIP, List.of("img.jpg"), 1L);
+
+			assertThatThrownBy(() -> community.update(null, null, List.of()))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.INVALID_TIP_UPLOAD);
+		}
+	}
+
+	@Nested
+	@DisplayName("Comment 도메인")
+	class CommentDomain {
+
+		@Test
+		@DisplayName("null 내용으로 생성하면 INVALID_COMMENT_CONTENT 예외")
+		void createWithNullContent_throws() {
+			assertThatThrownBy(() -> Comment.create(1L, 1L, null, null))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.INVALID_COMMENT_CONTENT);
+		}
+
+		@Test
+		@DisplayName("빈 내용으로 생성하면 INVALID_COMMENT_CONTENT 예외")
+		void createWithEmptyContent_throws() {
+			assertThatThrownBy(() -> Comment.create(1L, 1L, "", null))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.INVALID_COMMENT_CONTENT);
+		}
+
+		@Test
+		@DisplayName("softDelete 시 deleted=true, 내용이 삭제 메시지로 변경")
+		void softDelete_setsDeletedAndChangesContent() {
+			Comment comment = Comment.create(1L, 1L, "original content", null);
+			comment.softDelete();
+
+			assertThat(comment.isDeleted()).isTrue();
+			assertThat(comment.getContent()).isEqualTo("삭제된 메시지입니다");
+		}
+
+		@Test
+		@DisplayName("update 시 null 내용이면 INVALID_COMMENT_CONTENT 예외")
+		void updateWithNullContent_throws() {
+			Comment comment = Comment.create(1L, 1L, "original", null);
+
+			assertThatThrownBy(() -> comment.update(null))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.INVALID_COMMENT_CONTENT);
+		}
+
+		@Test
+		@DisplayName("update 시 빈 내용이면 INVALID_COMMENT_CONTENT 예외")
+		void updateWithEmptyContent_throws() {
+			Comment comment = Comment.create(1L, 1L, "original", null);
+
+			assertThatThrownBy(() -> comment.update(""))
+				.isInstanceOf(CommonException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.INVALID_COMMENT_CONTENT);
+		}
+	}
+
+	@Nested
+	@DisplayName("Like 도메인")
+	class LikeDomain {
+
+		@Test
+		@DisplayName("Like.of 생성 시 isLiked=true")
+		void of_createsWithIsLikedTrue() {
+			Like like = Like.of(1L, 10L);
+
+			assertThat(like.isLiked()).isTrue();
+			assertThat(like.getUserId()).isEqualTo(1L);
+			assertThat(like.getCommunityId()).isEqualTo(10L);
+		}
+
+		@Test
+		@DisplayName("unlike 후 like하면 isLiked 복원")
+		void toggleLikeUnlike() {
+			Like like = Like.of(1L, 10L);
+
+			like.unlike();
+			assertThat(like.isLiked()).isFalse();
+
+			like.like();
+			assertThat(like.isLiked()).isTrue();
+		}
+	}
+}

--- a/src/test/java/tave/crezipsa/crezipsa/domain/community/domain/CommunityDomainTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/domain/community/domain/CommunityDomainTest.java
@@ -20,6 +20,7 @@ class CommunityDomainTest {
 		@Test
 		@DisplayName("TIP 필드에 이미지 없으면 INVALID_TIP_UPLOAD 예외")
 		void tipFieldWithoutImages_throws() {
+			// when & then
 			assertThatThrownBy(() ->
 				Community.create("title", "content", CommunityField.TIP, null, 1L)
 			)
@@ -31,6 +32,7 @@ class CommunityDomainTest {
 		@Test
 		@DisplayName("TIP 필드에 빈 이미지 목록이면 INVALID_TIP_UPLOAD 예외")
 		void tipFieldWithEmptyImages_throws() {
+			// when & then
 			assertThatThrownBy(() ->
 				Community.create("title", "content", CommunityField.TIP, List.of(), 1L)
 			)
@@ -42,8 +44,10 @@ class CommunityDomainTest {
 		@Test
 		@DisplayName("TIP 필드에 이미지 있으면 정상 생성")
 		void tipFieldWithImages_succeeds() {
+			// when
 			Community community = Community.create("title", "content", CommunityField.TIP, List.of("img.jpg"), 1L);
 
+			// then
 			assertThat(community.getField()).isEqualTo(CommunityField.TIP);
 			assertThat(community.getImageUrls()).containsExactly("img.jpg");
 			assertThat(community.getLikeCount()).isZero();
@@ -52,6 +56,7 @@ class CommunityDomainTest {
 		@Test
 		@DisplayName("null 필드면 INVALID_FIELD_TYPE 예외")
 		void nullField_throwsInvalidFieldType() {
+			// when & then
 			assertThatThrownBy(() ->
 				Community.create("title", "content", null, null, 1L)
 			)
@@ -63,8 +68,10 @@ class CommunityDomainTest {
 		@Test
 		@DisplayName("RECOMMEND 필드는 이미지 없이 생성 가능")
 		void recommendFieldWithoutImages_succeeds() {
+			// when
 			Community community = Community.create("title", "content", CommunityField.RECOMMEND, null, 1L);
 
+			// then
 			assertThat(community.getImageUrls()).isEmpty();
 			assertThat(community.getLikeCount()).isZero();
 			assertThat(community.getWriterId()).isEqualTo(1L);
@@ -78,19 +85,27 @@ class CommunityDomainTest {
 		@Test
 		@DisplayName("좋아요 증가")
 		void increase() {
+			// given
 			Community community = Community.create("t", "c", CommunityField.RECOMMEND, null, 1L);
+
+			// when
 			community.increaseLikeCount();
 			community.increaseLikeCount();
 
+			// then
 			assertThat(community.getLikeCount()).isEqualTo(2L);
 		}
 
 		@Test
 		@DisplayName("좋아요 감소 시 0 이하로 내려가지 않음")
 		void decreaseFloorAtZero() {
+			// given
 			Community community = Community.create("t", "c", CommunityField.RECOMMEND, null, 1L);
+
+			// when
 			community.decreaseLikeCount();
 
+			// then
 			assertThat(community.getLikeCount()).isZero();
 		}
 	}
@@ -102,9 +117,13 @@ class CommunityDomainTest {
 		@Test
 		@DisplayName("null 필드는 업데이트하지 않음 (선택적 업데이트)")
 		void selectiveUpdate() {
+			// given
 			Community community = Community.create("title", "content", CommunityField.RECOMMEND, null, 1L);
+
+			// when
 			community.update("new title", null, null);
 
+			// then
 			assertThat(community.getTitle()).isEqualTo("new title");
 			assertThat(community.getContent()).isEqualTo("content");
 		}
@@ -112,8 +131,10 @@ class CommunityDomainTest {
 		@Test
 		@DisplayName("TIP 필드 커뮤니티에서 이미지를 빈 목록으로 업데이트하면 예외")
 		void updateTipCommunityWithEmptyImages_throws() {
+			// given
 			Community community = Community.create("title", "content", CommunityField.TIP, List.of("img.jpg"), 1L);
 
+			// when & then
 			assertThatThrownBy(() -> community.update(null, null, List.of()))
 				.isInstanceOf(CommonException.class)
 				.extracting("errorCode")
@@ -128,6 +149,7 @@ class CommunityDomainTest {
 		@Test
 		@DisplayName("null 내용으로 생성하면 INVALID_COMMENT_CONTENT 예외")
 		void createWithNullContent_throws() {
+			// when & then
 			assertThatThrownBy(() -> Comment.create(1L, 1L, null, null))
 				.isInstanceOf(CommonException.class)
 				.extracting("errorCode")
@@ -137,6 +159,7 @@ class CommunityDomainTest {
 		@Test
 		@DisplayName("빈 내용으로 생성하면 INVALID_COMMENT_CONTENT 예외")
 		void createWithEmptyContent_throws() {
+			// when & then
 			assertThatThrownBy(() -> Comment.create(1L, 1L, "", null))
 				.isInstanceOf(CommonException.class)
 				.extracting("errorCode")
@@ -146,9 +169,13 @@ class CommunityDomainTest {
 		@Test
 		@DisplayName("softDelete 시 deleted=true, 내용이 삭제 메시지로 변경")
 		void softDelete_setsDeletedAndChangesContent() {
+			// given
 			Comment comment = Comment.create(1L, 1L, "original content", null);
+
+			// when
 			comment.softDelete();
 
+			// then
 			assertThat(comment.isDeleted()).isTrue();
 			assertThat(comment.getContent()).isEqualTo("삭제된 메시지입니다");
 		}
@@ -156,8 +183,10 @@ class CommunityDomainTest {
 		@Test
 		@DisplayName("update 시 null 내용이면 INVALID_COMMENT_CONTENT 예외")
 		void updateWithNullContent_throws() {
+			// given
 			Comment comment = Comment.create(1L, 1L, "original", null);
 
+			// when & then
 			assertThatThrownBy(() -> comment.update(null))
 				.isInstanceOf(CommonException.class)
 				.extracting("errorCode")
@@ -167,8 +196,10 @@ class CommunityDomainTest {
 		@Test
 		@DisplayName("update 시 빈 내용이면 INVALID_COMMENT_CONTENT 예외")
 		void updateWithEmptyContent_throws() {
+			// given
 			Comment comment = Comment.create(1L, 1L, "original", null);
 
+			// when & then
 			assertThatThrownBy(() -> comment.update(""))
 				.isInstanceOf(CommonException.class)
 				.extracting("errorCode")
@@ -183,8 +214,10 @@ class CommunityDomainTest {
 		@Test
 		@DisplayName("Like.of 생성 시 isLiked=true")
 		void of_createsWithIsLikedTrue() {
+			// when
 			Like like = Like.of(1L, 10L);
 
+			// then
 			assertThat(like.isLiked()).isTrue();
 			assertThat(like.getUserId()).isEqualTo(1L);
 			assertThat(like.getCommunityId()).isEqualTo(10L);
@@ -193,8 +226,10 @@ class CommunityDomainTest {
 		@Test
 		@DisplayName("unlike 후 like하면 isLiked 복원")
 		void toggleLikeUnlike() {
+			// given
 			Like like = Like.of(1L, 10L);
 
+			// when & then
 			like.unlike();
 			assertThat(like.isLiked()).isFalse();
 

--- a/src/test/java/tave/crezipsa/crezipsa/fixture/ChatFixture.java
+++ b/src/test/java/tave/crezipsa/crezipsa/fixture/ChatFixture.java
@@ -1,0 +1,41 @@
+package tave.crezipsa.crezipsa.fixture;
+
+import java.time.LocalDateTime;
+
+import tave.crezipsa.crezipsa.domain.chat.entity.ChatMessage;
+import tave.crezipsa.crezipsa.domain.chat.entity.ChatRoom;
+
+public final class ChatFixture {
+
+	private ChatFixture() {
+	}
+
+	public static ChatRoom createChatRoom(Long id, Long userId) {
+		return ChatRoom.builder()
+			.id(id)
+			.userId(userId)
+			.title("테스트 채팅방")
+			.createdAt(LocalDateTime.now())
+			.build();
+	}
+
+	public static ChatMessage createUserMessage(Long id, Long chatRoomId) {
+		return ChatMessage.builder()
+			.id(id)
+			.chatRoomId(chatRoomId)
+			.senderType(ChatMessage.SenderType.USER)
+			.content("사용자 메시지")
+			.createdAt(LocalDateTime.now())
+			.build();
+	}
+
+	public static ChatMessage createAiMessage(Long id, Long chatRoomId) {
+		return ChatMessage.builder()
+			.id(id)
+			.chatRoomId(chatRoomId)
+			.senderType(ChatMessage.SenderType.AI)
+			.content("AI 응답 메시지")
+			.createdAt(LocalDateTime.now())
+			.build();
+	}
+}

--- a/src/test/java/tave/crezipsa/crezipsa/fixture/CommentFixture.java
+++ b/src/test/java/tave/crezipsa/crezipsa/fixture/CommentFixture.java
@@ -1,0 +1,25 @@
+package tave.crezipsa.crezipsa.fixture;
+
+import java.time.LocalDateTime;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+import tave.crezipsa.crezipsa.domain.community.domain.Comment;
+
+public final class CommentFixture {
+
+	private CommentFixture() {
+	}
+
+	public static Comment createComment(Long commentId, Long communityId, Long userId, Long parentId) {
+		Comment comment = Comment.builder()
+			.commentId(commentId)
+			.communityId(communityId)
+			.userId(userId)
+			.content("test comment")
+			.parentId(parentId)
+			.build();
+		ReflectionTestUtils.setField(comment, "createdAt", LocalDateTime.now());
+		return comment;
+	}
+}

--- a/src/test/java/tave/crezipsa/crezipsa/fixture/CommunityFixture.java
+++ b/src/test/java/tave/crezipsa/crezipsa/fixture/CommunityFixture.java
@@ -1,0 +1,33 @@
+package tave.crezipsa.crezipsa.fixture;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+import tave.crezipsa.crezipsa.domain.community.domain.Community;
+import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
+
+public final class CommunityFixture {
+
+	private CommunityFixture() {
+	}
+
+	public static Community createCommunity(Long id, Long writerId) {
+		Community community = Community.builder()
+			.communityId(id)
+			.title("테스트 제목")
+			.content("테스트 내용입니다. 충분히 긴 내용으로 preview 테스트도 가능합니다.")
+			.field(CommunityField.RECOMMEND)
+			.imageUrls(List.of("img1.jpg"))
+			.writerId(writerId)
+			.likeCount(0L)
+			.build();
+		ReflectionTestUtils.setField(community, "createdAt", LocalDateTime.now());
+		return community;
+	}
+
+	public static Community createCommunity(Long id) {
+		return createCommunity(id, 1L);
+	}
+}

--- a/src/test/java/tave/crezipsa/crezipsa/fixture/StoryboardFixture.java
+++ b/src/test/java/tave/crezipsa/crezipsa/fixture/StoryboardFixture.java
@@ -1,0 +1,44 @@
+package tave.crezipsa.crezipsa.fixture;
+
+import java.time.LocalDateTime;
+
+import tave.crezipsa.crezipsa.domain.storyboard.entity.Storyboard;
+import tave.crezipsa.crezipsa.domain.storyboard.entity.StoryboardCut;
+
+public final class StoryboardFixture {
+
+	private StoryboardFixture() {
+	}
+
+	public static Storyboard createStoryboard(Long id, Long userId) {
+		return Storyboard.builder()
+			.id(id)
+			.userId(userId)
+			.title("테스트 스토리보드")
+			.sourceChatMessageId(null)
+			.createdAt(LocalDateTime.now())
+			.build();
+	}
+
+	public static Storyboard createStoryboard(Long id, Long userId, Long sourceChatMessageId) {
+		return Storyboard.builder()
+			.id(id)
+			.userId(userId)
+			.title("테스트 스토리보드")
+			.sourceChatMessageId(sourceChatMessageId)
+			.createdAt(LocalDateTime.now())
+			.build();
+	}
+
+	public static StoryboardCut createStoryboardCut(Long id, Long storyboardId, int order) {
+		return StoryboardCut.builder()
+			.id(id)
+			.storyboardId(storyboardId)
+			.order(order)
+			.cutComposition("컷 구도")
+			.script("스크립트")
+			.caption("캡션")
+			.etc("기타")
+			.build();
+	}
+}

--- a/src/test/java/tave/crezipsa/crezipsa/fixture/UserFixture.java
+++ b/src/test/java/tave/crezipsa/crezipsa/fixture/UserFixture.java
@@ -1,0 +1,21 @@
+package tave.crezipsa.crezipsa.fixture;
+
+import tave.crezipsa.crezipsa.domain.user.entity.User;
+import tave.crezipsa.crezipsa.domain.user.enums.Platform;
+
+public final class UserFixture {
+
+	private UserFixture() {
+	}
+
+	public static User createUser(Long userId) {
+		return User.builder()
+			.userId(userId)
+			.nickName("user" + userId)
+			.email("user" + userId + "@test.com")
+			.profileImageUrl("profile.jpg")
+			.mainPlatform(Platform.YOUTUBE)
+			.activeYoutube("yt" + userId)
+			.build();
+	}
+}


### PR DESCRIPTION
## Summary
- community usecase 테스트 3종을 추가해 주요 비즈니스 분기(권한, 존재 여부, 토글, 트리 조합, 예외 코드)를 검증했습니다.
- community domain 테스트를 추가해 핵심 도메인 규칙(TIP 이미지 규칙, like count 경계, comment/like 상태 전이)을 검증했습니다.
- JaCoCo 리포트 의존성을 반영하고, 테스트 커버리지 수치와 해석 기준을 PR 본문에 명시했습니다.

## Test Scope
- `src/test/java/tave/crezipsa/crezipsa/application/community/usecase/CommunityUseCaseImplTest.java`
- `src/test/java/tave/crezipsa/crezipsa/application/community/usecase/CommentUseCaseImplTest.java`
- `src/test/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImplTest.java`
- `src/test/java/tave/crezipsa/crezipsa/domain/community/domain/CommunityDomainTest.java`
- `build.gradle` (JaCoCo report 설정 포함)

## Test Coverage (JaCoCo)
기준 파일: `build/reports/jacoco/test/jacocoTestReport.xml`

- 전체 프로젝트
  - LINE: `21.18%` (330/1558)
  - BRANCH: `24.54%` (66/269)
  - METHOD: `19.09%` (88/461)

- community 관련 핵심 클래스
  - `CommunityUseCaseImpl`
    - LINE: `54.55%` (42/77)
    - BRANCH: `66.67%` (12/18)
    - METHOD: `47.06%` (8/17)
  - `CommentUseCaseImpl`
    - LINE: `73.33%` (55/75)
    - BRANCH: `79.17%` (19/24)
    - METHOD: `78.95%` (15/19)
  - `LikeUseCaseImpl`
    - LINE: `73.81%` (31/42)
    - BRANCH: `50.00%` (7/14)
    - METHOD: `70.00%` (7/10)
  - `Community` (domain)
    - LINE: `92.31%` (24/26)
    - BRANCH: `94.44%` (17/18)
  - `Comment` (domain)
    - LINE: `86.67%` (13/15)
    - BRANCH: `87.50%` (7/8)
  - `Like` (domain)
    - LINE: `100%` (10/10)

## Coverage Interpretation Guide
- LINE은 "코드가 실행됐는지"를, BRANCH는 "조건 분기의 참/거짓을 모두 검증했는지"를 보여줍니다.
- domain 커버리지가 usecase보다 높은 것은 도메인 규칙 검증이 탄탄하다는 신호입니다.
- 반대로 usecase의 상대적 저커버리지는 서비스 조합 로직(정렬/검색/페이지/조회 조합)의 분기 보강 여지가 있다는 의미입니다.
- 다음 보강 우선순위
  1. `CommunityUseCaseImpl`의 search/sort/paging 분기
  2. `LikeUseCaseImpl`의 unlike/재토글 경계 분기
  3. 조회 조합에서 null/empty/권한 경계 케이스

## How To Read These Tests
- `@Nested` + `@DisplayName`로 유스케이스 시나리오를 구획했습니다.
- 실패 경로는 `CommonException`의 `errorCode`까지 검증하여 요구사항-예외 매핑을 명확히 했습니다.
- 성공 경로는 상태 변경 + repository interaction(`verify`, `never`, `times`)을 함께 검증합니다.

## 관련사진

<img width="1146" height="408" alt="스크린샷 2026-02-09 오후 11 13 42" src="https://github.com/user-attachments/assets/64765b19-e1c5-4852-adbc-57f410a64123" />
<img width="1114" height="405" alt="스크린샷 2026-02-09 오후 11 13 16" src="https://github.com/user-attachments/assets/807916ee-5733-4a31-9a31-e45aa46edf10" />
<img width="1107" height="397" alt="스크린샷 2026-02-09 오후 11 13 28" src="https://github.com/user-attachments/assets/d000a24f-a0d8-4e4c-801c-654c10150e07" />
<img width="1099" height="424" alt="스크린샷 2026-02-09 오후 11 13 03" src="https://github.com/user-attachments/assets/b58b0738-0a9c-4a4c-95e1-669ede81cb21" />


## Test Run
```bash
./gradlew test
```
- 결과: `BUILD SUCCESSFUL`