### PR TITLE
[refactor] Redis 기반 JWT 토큰 블랙리스트 도입 (#59)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,10 @@ out/
 ### VS Code ###
 .vscode/
 
+# mysql local volume
+docker/mysql/data/
+docker/mysql/data/**
+
 # OpenCode / oh-my-opencode
 .opencode/
 !.opencode/oh-my-opencode.json

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,8 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.testcontainers:testcontainers:1.20.4'
+    testImplementation 'org.testcontainers:junit-jupiter:1.20.4'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testRuntimeOnly 'com.h2database:h2'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
     //jdbc
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     //XML <-> 자바 객체 변환
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.2'
     implementation 'org.glassfish.jaxb:jaxb-runtime:4.0.5'

--- a/src/main/java/tave/crezipsa/crezipsa/application/auth/usecase/AuthUsecaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/auth/usecase/AuthUsecaseImpl.java
@@ -12,6 +12,7 @@ import tave.crezipsa.crezipsa.global.common.dto.GlobalResponseDto;
 import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
 import tave.crezipsa.crezipsa.global.exception.model.CommonException;
 import tave.crezipsa.crezipsa.global.security.JwtTokenProvider;
+import tave.crezipsa.crezipsa.global.security.TokenBlacklistService;
 
 @Slf4j
 @Service
@@ -21,6 +22,7 @@ public class AuthUsecaseImpl implements AuthUsecase {
 
     private final AuthRepository authRepository;
     private final JwtTokenProvider tokenProvider;
+    private final TokenBlacklistService tokenBlacklistService;
 
     @Override
     public TokenResponse reissueAccessToken(RefreshTokenRequest refreshTokenRequest) {
@@ -37,6 +39,11 @@ public class AuthUsecaseImpl implements AuthUsecase {
 
     @Override
     public void deleteToken(Long userId) {
+        authRepository.findByUserId(userId).ifPresent(auth -> {
+            String accessToken = auth.getAccessToken();
+            long remainingMs = tokenProvider.getRemainingExpiration(accessToken);
+            tokenBlacklistService.blacklist(accessToken, remainingMs);
+        });
         authRepository.deleteByUserId(userId);
     }
 

--- a/src/main/java/tave/crezipsa/crezipsa/application/auth/usecase/KakaoLoginUsecase.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/auth/usecase/KakaoLoginUsecase.java
@@ -47,7 +47,7 @@ public class KakaoLoginUsecase {
                         .build()
                 );
 
-        auth.updateTokens(kakaoToken, refreshToken);
+        auth.updateTokens(jwt, refreshToken);
         authRepository.save(auth);
 
         return LoginResponse.success(jwt, refreshToken, kakaoUserInfo);
@@ -80,7 +80,7 @@ public class KakaoLoginUsecase {
                         .build()
                 );
 
-        auth.updateTokens(kakaoToken, refreshToken);
+        auth.updateTokens(jwt, refreshToken);
         authRepository.save(auth);
 
         return LoginResponse.success(jwt, refreshToken, kakaoUserInfo);

--- a/src/main/java/tave/crezipsa/crezipsa/global/config/RedisConfig.java
+++ b/src/main/java/tave/crezipsa/crezipsa/global/config/RedisConfig.java
@@ -1,0 +1,22 @@
+package tave.crezipsa.crezipsa.global.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+	@Bean
+	@ConditionalOnBean(RedisConnectionFactory.class)
+	public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+		RedisTemplate<String, String> template = new RedisTemplate<>();
+		template.setConnectionFactory(connectionFactory);
+		template.setKeySerializer(new StringRedisSerializer());
+		template.setValueSerializer(new StringRedisSerializer());
+		return template;
+	}
+}

--- a/src/main/java/tave/crezipsa/crezipsa/global/exception/code/ErrorCode.java
+++ b/src/main/java/tave/crezipsa/crezipsa/global/exception/code/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode implements BaseErrorCode {
 	INVALID_TOKEN(401, "A40102", "토큰이 유효하지 않습니다."),
 	INVALID_REFRESH_TOKEN(401, "A40103", "일치하지 않는 AccessToken입니다."),
 	TOKEN_EXPIRED(401,"A40104","토큰 유효시간이 만료되었습니다."),
+	TOKEN_BLACKLISTED(401, "A40107", "로그아웃된 토큰입니다."),
 	KAKAO_USERINFO_FAILED(400, "A40105", "카카오 사용자 정보를 가져오지 못했습니다."),
 	KAKAO_HEADER_NOT_FOUND(400, "A40106", "카카오 토큰 헤더가 누락되었습니다."),
 

--- a/src/main/java/tave/crezipsa/crezipsa/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/tave/crezipsa/crezipsa/global/security/JwtAuthenticationFilter.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
 import tave.crezipsa.crezipsa.global.exception.model.CommonException;
+import tave.crezipsa.crezipsa.global.exception.model.JwtAuthenticationException;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -25,6 +26,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
+    private final TokenBlacklistService tokenBlacklistService;
 
     @Override
     public void doFilterInternal(HttpServletRequest request,
@@ -36,6 +38,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (token != null) {
             jwtTokenProvider.validateToken(token);
+
+            if (tokenBlacklistService.isBlacklisted(token)) {
+                throw new JwtAuthenticationException(ErrorCode.TOKEN_BLACKLISTED);
+            }
+
             Long userId = jwtTokenProvider.getUserIdFromToken(token);
 
             // DB에서 User 엔티티 조회

--- a/src/main/java/tave/crezipsa/crezipsa/global/security/JwtTokenProvider.java
+++ b/src/main/java/tave/crezipsa/crezipsa/global/security/JwtTokenProvider.java
@@ -63,14 +63,18 @@ public class JwtTokenProvider {
         }
     }
 
-    //토큰 남은 만료 시간(ms) 추출
+    //토큰 남은 만료 시간(ms) 추출 — 이미 만료된 토큰은 0 반환
     public long getRemainingExpiration(String token) {
-        Date expiration = Jwts.parser()
-                .setSigningKey(secretKey)
-                .parseClaimsJws(token)
-                .getBody()
-                .getExpiration();
-        return expiration.getTime() - System.currentTimeMillis();
+        try {
+            Date expiration = Jwts.parser()
+                    .setSigningKey(secretKey)
+                    .parseClaimsJws(token)
+                    .getBody()
+                    .getExpiration();
+            return Math.max(0, expiration.getTime() - System.currentTimeMillis());
+        } catch (ExpiredJwtException e) {
+            return 0;
+        }
     }
 
     //토큰에서 user 추출

--- a/src/main/java/tave/crezipsa/crezipsa/global/security/JwtTokenProvider.java
+++ b/src/main/java/tave/crezipsa/crezipsa/global/security/JwtTokenProvider.java
@@ -63,6 +63,16 @@ public class JwtTokenProvider {
         }
     }
 
+    //토큰 남은 만료 시간(ms) 추출
+    public long getRemainingExpiration(String token) {
+        Date expiration = Jwts.parser()
+                .setSigningKey(secretKey)
+                .parseClaimsJws(token)
+                .getBody()
+                .getExpiration();
+        return expiration.getTime() - System.currentTimeMillis();
+    }
+
     //토큰에서 user 추출
     public Long getUserIdFromToken(String token) {
         return Long.valueOf(Jwts.parser()

--- a/src/main/java/tave/crezipsa/crezipsa/global/security/TokenBlacklistService.java
+++ b/src/main/java/tave/crezipsa/crezipsa/global/security/TokenBlacklistService.java
@@ -6,7 +6,9 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TokenBlacklistService {
@@ -16,13 +18,23 @@ public class TokenBlacklistService {
 	private final RedisTemplate<String, String> redisTemplate;
 
 	public void blacklist(String token, long remainingMs) {
-		if (remainingMs > 0) {
+		if (remainingMs <= 0) {
+			return;
+		}
+		try {
 			redisTemplate.opsForValue()
 				.set(BLACKLIST_PREFIX + token, "logout", remainingMs, TimeUnit.MILLISECONDS);
+		} catch (Exception e) {
+			log.warn("Redis 블랙리스트 등록 실패 — 토큰은 자연 만료까지 유효합니다: {}", e.getMessage());
 		}
 	}
 
 	public boolean isBlacklisted(String token) {
-		return Boolean.TRUE.equals(redisTemplate.hasKey(BLACKLIST_PREFIX + token));
+		try {
+			return Boolean.TRUE.equals(redisTemplate.hasKey(BLACKLIST_PREFIX + token));
+		} catch (Exception e) {
+			log.warn("Redis 블랙리스트 조회 실패 — 요청을 허용합니다: {}", e.getMessage());
+			return false;
+		}
 	}
 }

--- a/src/main/java/tave/crezipsa/crezipsa/global/security/TokenBlacklistService.java
+++ b/src/main/java/tave/crezipsa/crezipsa/global/security/TokenBlacklistService.java
@@ -1,0 +1,28 @@
+package tave.crezipsa.crezipsa.global.security;
+
+import java.util.concurrent.TimeUnit;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TokenBlacklistService {
+
+	private static final String BLACKLIST_PREFIX = "blacklist:";
+
+	private final RedisTemplate<String, String> redisTemplate;
+
+	public void blacklist(String token, long remainingMs) {
+		if (remainingMs > 0) {
+			redisTemplate.opsForValue()
+				.set(BLACKLIST_PREFIX + token, "logout", remainingMs, TimeUnit.MILLISECONDS);
+		}
+	}
+
+	public boolean isBlacklisted(String token) {
+		return Boolean.TRUE.equals(redisTemplate.hasKey(BLACKLIST_PREFIX + token));
+	}
+}

--- a/src/test/java/tave/crezipsa/crezipsa/application/auth/usecase/AuthUsecaseImplTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/application/auth/usecase/AuthUsecaseImplTest.java
@@ -1,0 +1,80 @@
+package tave.crezipsa.crezipsa.application.auth.usecase;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import tave.crezipsa.crezipsa.domain.auth.entity.Auth;
+import tave.crezipsa.crezipsa.domain.auth.repository.AuthRepository;
+import tave.crezipsa.crezipsa.global.security.JwtTokenProvider;
+import tave.crezipsa.crezipsa.global.security.TokenBlacklistService;
+
+@ExtendWith(MockitoExtension.class)
+class AuthUsecaseImplTest {
+
+	@Mock
+	private AuthRepository authRepository;
+
+	@Mock
+	private JwtTokenProvider tokenProvider;
+
+	@Mock
+	private TokenBlacklistService tokenBlacklistService;
+
+	@InjectMocks
+	private AuthUsecaseImpl authUsecase;
+
+	@Nested
+	@DisplayName("deleteToken")
+	class DeleteToken {
+
+		@Test
+		@DisplayName("Auth가 존재하면 accessToken을 블랙리스트에 등록하고 삭제한다")
+		void deleteToken_withAuth_blacklistsAndDeletes() {
+			// Given
+			Long userId = 1L;
+			String accessToken = "test-access-token";
+			long remainingMs = 60000L;
+
+			Auth auth = Auth.builder()
+				.authId(1L)
+				.userId(userId)
+				.accessToken(accessToken)
+				.refreshToken("test-refresh-token")
+				.build();
+
+			when(authRepository.findByUserId(userId)).thenReturn(Optional.of(auth));
+			when(tokenProvider.getRemainingExpiration(accessToken)).thenReturn(remainingMs);
+
+			// When
+			authUsecase.deleteToken(userId);
+
+			// Then
+			verify(tokenBlacklistService).blacklist(accessToken, remainingMs);
+			verify(authRepository).deleteByUserId(userId);
+		}
+
+		@Test
+		@DisplayName("Auth가 존재하지 않으면 블랙리스트 등록 없이 삭제만 수행한다")
+		void deleteToken_withoutAuth_onlyDeletes() {
+			// Given
+			Long userId = 1L;
+			when(authRepository.findByUserId(userId)).thenReturn(Optional.empty());
+
+			// When
+			authUsecase.deleteToken(userId);
+
+			// Then
+			verify(authRepository).deleteByUserId(userId);
+		}
+	}
+}

--- a/src/test/java/tave/crezipsa/crezipsa/global/config/TestRedisConfig.java
+++ b/src/test/java/tave/crezipsa/crezipsa/global/config/TestRedisConfig.java
@@ -1,0 +1,21 @@
+package tave.crezipsa.crezipsa.global.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import static org.mockito.Mockito.mock;
+
+@Configuration
+@Profile("test")
+public class TestRedisConfig {
+
+	@SuppressWarnings("unchecked")
+	@Bean
+	@ConditionalOnMissingBean(RedisTemplate.class)
+	public RedisTemplate<String, String> redisTemplate() {
+		return mock(RedisTemplate.class);
+	}
+}

--- a/src/test/java/tave/crezipsa/crezipsa/global/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/global/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,119 @@
+package tave.crezipsa.crezipsa.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static tave.crezipsa.crezipsa.fixture.UserFixture.createUser;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import jakarta.servlet.FilterChain;
+import tave.crezipsa.crezipsa.domain.user.entity.User;
+import tave.crezipsa.crezipsa.domain.user.repository.UserRepository;
+import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
+import tave.crezipsa.crezipsa.global.exception.model.JwtAuthenticationException;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+
+	@Mock
+	private JwtTokenProvider jwtTokenProvider;
+
+	@Mock
+	private UserRepository userRepository;
+
+	@Mock
+	private TokenBlacklistService tokenBlacklistService;
+
+	@Mock
+	private FilterChain filterChain;
+
+	@InjectMocks
+	private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+	private MockHttpServletRequest request;
+	private MockHttpServletResponse response;
+
+	@BeforeEach
+	void setUp() {
+		request = new MockHttpServletRequest();
+		response = new MockHttpServletResponse();
+		SecurityContextHolder.clearContext();
+	}
+
+	@Nested
+	@DisplayName("doFilterInternal")
+	class DoFilterInternal {
+
+		@Test
+		@DisplayName("블랙리스트된 토큰이면 JwtAuthenticationException을 던진다")
+		void blacklistedToken_throwsJwtAuthenticationException() {
+			// Given
+			String token = "blacklisted-token";
+			request.addHeader("Authorization", "Bearer " + token);
+			when(tokenBlacklistService.isBlacklisted(token)).thenReturn(true);
+
+			// When & Then
+			assertThatThrownBy(() ->
+				jwtAuthenticationFilter.doFilterInternal(request, response, filterChain)
+			)
+				.isInstanceOf(JwtAuthenticationException.class)
+				.satisfies(ex -> {
+					JwtAuthenticationException jwtEx = (JwtAuthenticationException) ex;
+					assertThat(jwtEx.getErrorCode()).isEqualTo(ErrorCode.TOKEN_BLACKLISTED);
+				});
+
+			verify(jwtTokenProvider).validateToken(token);
+			verify(jwtTokenProvider, never()).getUserIdFromToken(token);
+		}
+
+		@Test
+		@DisplayName("블랙리스트에 없는 유효한 토큰이면 인증을 설정한다")
+		void validToken_setsAuthentication() throws Exception {
+			// Given
+			String token = "valid-token";
+			Long userId = 1L;
+			User user = createUser(userId);
+
+			request.addHeader("Authorization", "Bearer " + token);
+			when(tokenBlacklistService.isBlacklisted(token)).thenReturn(false);
+			when(jwtTokenProvider.getUserIdFromToken(token)).thenReturn(userId);
+			when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+			// When
+			jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+			// Then
+			assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+			assertThat(SecurityContextHolder.getContext().getAuthentication().getPrincipal()).isEqualTo(user);
+			verify(filterChain).doFilter(request, response);
+		}
+
+		@Test
+		@DisplayName("Authorization 헤더가 없으면 인증을 설정하지 않는다")
+		void noAuthHeader_skipsAuthentication() throws Exception {
+			// Given — 헤더 없음
+
+			// When
+			jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+			// Then
+			assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+			verify(filterChain).doFilter(request, response);
+		}
+	}
+}

--- a/src/test/java/tave/crezipsa/crezipsa/global/security/TokenBlacklistServiceIntegrationTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/global/security/TokenBlacklistServiceIntegrationTest.java
@@ -1,0 +1,52 @@
+package tave.crezipsa.crezipsa.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest
+@ActiveProfiles("redis-test")
+@Testcontainers
+class TokenBlacklistServiceIntegrationTest {
+
+	@Container
+	static GenericContainer<?> redis =
+		new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+			.withExposedPorts(6379);
+
+	@DynamicPropertySource
+	static void redisProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.data.redis.host", redis::getHost);
+		registry.add("spring.data.redis.port", () -> redis.getMappedPort(6379));
+	}
+
+	@Autowired
+	private TokenBlacklistService tokenBlacklistService;
+
+	@Test
+	@DisplayName("실제 Redis에 블랙리스트 등록 후 조회되고 TTL 만료 후 사라진다")
+	void blacklistAndQuery_withRealRedis() throws InterruptedException {
+		// Given
+		String token = "real-test-token";
+
+		// When
+		tokenBlacklistService.blacklist(token, 2000L);
+
+		// Then - 등록 직후 조회
+		assertThat(tokenBlacklistService.isBlacklisted(token)).isTrue();
+
+		// Then - TTL 만료 후 조회
+		Thread.sleep(2500L);
+		assertThat(tokenBlacklistService.isBlacklisted(token)).isFalse();
+	}
+}

--- a/src/test/java/tave/crezipsa/crezipsa/global/security/TokenBlacklistServiceTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/global/security/TokenBlacklistServiceTest.java
@@ -1,0 +1,104 @@
+package tave.crezipsa.crezipsa.global.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+@ExtendWith(MockitoExtension.class)
+class TokenBlacklistServiceTest {
+
+	@Mock
+	private RedisTemplate<String, String> redisTemplate;
+
+	@Mock
+	private ValueOperations<String, String> valueOperations;
+
+	@InjectMocks
+	private TokenBlacklistService tokenBlacklistService;
+
+	@Nested
+	@DisplayName("blacklist")
+	class Blacklist {
+
+		@Test
+		@DisplayName("남은 TTL이 양수이면 Redis에 blacklist 키를 저장한다")
+		void blacklist_withPositiveTtl_savesToRedis() {
+			// Given
+			String token = "test-access-token";
+			long remainingMs = 60000L;
+			when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+
+			// When
+			tokenBlacklistService.blacklist(token, remainingMs);
+
+			// Then
+			verify(valueOperations).set(
+				eq("blacklist:" + token),
+				eq("logout"),
+				eq(remainingMs),
+				eq(TimeUnit.MILLISECONDS)
+			);
+		}
+
+		@Test
+		@DisplayName("남은 TTL이 0 이하이면 Redis에 저장하지 않는다")
+		void blacklist_withZeroOrNegativeTtl_doesNotSave() {
+			// Given
+			String token = "expired-token";
+			long remainingMs = 0L;
+
+			// When
+			tokenBlacklistService.blacklist(token, remainingMs);
+
+			// Then
+			verify(redisTemplate, never()).opsForValue();
+		}
+	}
+
+	@Nested
+	@DisplayName("isBlacklisted")
+	class IsBlacklisted {
+
+		@Test
+		@DisplayName("블랙리스트에 등록된 토큰이면 true를 반환한다")
+		void isBlacklisted_whenTokenExists_returnsTrue() {
+			// Given
+			String token = "blacklisted-token";
+			when(redisTemplate.hasKey("blacklist:" + token)).thenReturn(true);
+
+			// When
+			boolean result = tokenBlacklistService.isBlacklisted(token);
+
+			// Then
+			assertThat(result).isTrue();
+		}
+
+		@Test
+		@DisplayName("블랙리스트에 없는 토큰이면 false를 반환한다")
+		void isBlacklisted_whenTokenNotExists_returnsFalse() {
+			// Given
+			String token = "valid-token";
+			when(redisTemplate.hasKey("blacklist:" + token)).thenReturn(false);
+
+			// When
+			boolean result = tokenBlacklistService.isBlacklisted(token);
+
+			// Then
+			assertThat(result).isFalse();
+		}
+	}
+}


### PR DESCRIPTION
## 개요

로그아웃 시 DB의 Auth 레코드를 삭제하지만, **이미 발급된 JWT Access Token은 만료 전까지 여전히 유효한 보안 이슈**를 해결합니다.

Redis에 로그아웃된 토큰을 블랙리스트로 등록하여, JWT 필터에서 매 요청마다 블랙리스트 여부를 체크합니다. 블랙리스트에 등록된 토큰은 남은 만료시간(TTL)만큼만 Redis에 저장되어, 만료 후 자동으로 삭제됩니다.

---

## 변경 사항

### 1. 인프라 환경 세팅

| 파일 | 변경 내용 |
|------|----------|
| `build.gradle` | `spring-boot-starter-data-redis`, `testcontainers` 의존성 추가 |
| `docker/docker-compose.yml` | Redis 서비스 추가 (local, 포트 6379) |
| `docker/docker-compose.dev.yml` | Redis 서비스 추가 (dev, 포트 6380) |
| `docker/docker-compose.prod.yml` | Redis 서비스 추가 (prod, 포트 6381, backend-bridge 네트워크) |
| `application.yml` | `spring.data.redis.host/port` 환경변수 설정 추가 |
| `application-test.yml` | Redis AutoConfiguration exclude 추가 (단위 테스트에서 Redis 미연결) |
| `application-redis-test.yml` | 통합 테스트 전용 프로파일 신규 생성 |

### 2. 핵심 코드

| 파일 | 변경 내용 |
|------|----------|
| `RedisConfig.java` | **신규** — `RedisTemplate<String, String>` Bean 정의. `@ConditionalOnBean(RedisConnectionFactory.class)`로 테스트 환경에서 자동 skip |
| `TokenBlacklistService.java` | **신규** — `blacklist(token, remainingMs)`: 토큰을 남은 TTL만큼 Redis에 저장. `isBlacklisted(token)`: 블랙리스트 등록 여부 확인 |
| `ErrorCode.java` | `TOKEN_BLACKLISTED(401, "A40107", "로그아웃된 토큰입니다.")` 추가 |
| `JwtTokenProvider.java` | `getRemainingExpiration(token)` 메서드 추가 — 토큰의 남은 만료시간(ms) 계산 |
| `JwtAuthenticationFilter.java` | 토큰 검증 후 `tokenBlacklistService.isBlacklisted(token)` 체크 추가. 블랙리스트 토큰이면 `TOKEN_BLACKLISTED` 예외 발생 |
| `AuthUsecaseImpl.java` | `deleteToken()` 수정 — Auth 조회 → accessToken 추출 → 남은 TTL 계산 → Redis 블랙리스트 등록 → DB 삭제 |

### 3. 테스트

| 파일 | 테스트 내용 |
|------|----------|
| `TokenBlacklistServiceTest.java` | 단위 테스트 4건 — blacklist 정상 저장 / TTL 0 이하 시 미저장 / isBlacklisted true·false |
| `TokenBlacklistServiceIntegrationTest.java` | Testcontainers Redis 통합 테스트 1건 — 실제 Redis set → 조회 성공 → TTL 만료 후 소멸 검증 |
| `JwtAuthenticationFilterTest.java` | 단위 테스트 3건 — 블랙리스트 토큰 인증 실패 / 정상 토큰 인증 성공 / 헤더 없을 때 skip |
| `AuthUsecaseImplTest.java` | 단위 테스트 2건 — Auth 존재 시 블랙리스트 등록+삭제 / Auth 미존재 시 삭제만 |
| `TestRedisConfig.java` | `@Profile("test")` 환경에서 mock `RedisTemplate` 제공 |

---

## 흐름도

```
[로그아웃 요청]
    ↓
AuthUsecaseImpl.deleteToken(userId)
    ├─ Auth 조회 → accessToken 추출
    ├─ JwtTokenProvider.getRemainingExpiration(accessToken) → 남은 TTL 계산
    ├─ TokenBlacklistService.blacklist(accessToken, remainingMs) → Redis SET (TTL 자동 만료)
    └─ AuthRepository.deleteByUserId(userId) → DB 삭제

[이후 API 요청 with 로그아웃된 토큰]
    ↓
JwtAuthenticationFilter.doFilterInternal()
    ├─ JwtTokenProvider.validateToken(token) → 서명/만료 검증
    ├─ TokenBlacklistService.isBlacklisted(token) → Redis 조회
    │   └─ true → JwtAuthenticationException(TOKEN_BLACKLISTED) → 401 응답
    └─ false → 정상 인증 처리
```

---

## 배포 시 필요한 작업

- [x] GitHub Settings > Secrets에서 `DEV_ENV` 값에 `REDIS_HOST=redis`, `REDIS_PORT=6379` 추가
- [x] GitHub Settings > Secrets에서 `PROD_ENV` 값에 `REDIS_HOST=redis`, `REDIS_PORT=6379` 추가
- [x] EC2 서버에서 Docker 이미지 pull 후 `docker compose up -d`로 Redis 서비스 시작 확인

> `REDIS_HOST=redis`인 이유: Docker Compose 내부 네트워크에서 서비스명이 DNS 호스트명으로 사용됩니다.

---

## 셀프 피드백

### 잘한 점
- 토큰 TTL과 Redis TTL을 동기화하여 만료된 토큰이 Redis에 불필요하게 남지 않도록 설계
- 테스트 프로파일을 `test` / `redis-test`로 분리하여 단위 테스트와 통합 테스트 간 context 간섭 방지
- `@ConditionalOnBean(RedisConnectionFactory.class)` 적용으로 Redis 미연결 환경에서도 빌드 안정성 확보

### 개선 고려 사항
- **`deleteToken()`의 accessToken 만료 예외 처리**: 현재 `getRemainingExpiration()`은 이미 만료된 토큰에 대해 `ExpiredJwtException`을 던질 수 있음. 로그아웃 시점에 토큰이 이미 만료된 경우 블랙리스트 등록을 skip하는 try-catch가 필요할 수 있음
- **Redis 장애 시 Fallback**: 현재 Redis 연결 실패 시 `isBlacklisted()`가 예외를 던져 모든 요청이 실패할 수 있음. Redis 장애 시 false를 반환하는 방어 로직 추가를 고려할 수 있음 (보안 vs 가용성 트레이드오프)
- **Refresh Token 블랙리스트**: 현재 Access Token만 블랙리스트에 등록하지만, Refresh Token도 함께 블랙리스트에 등록하면 토큰 재발급까지 완전 차단 가능
- **`docker-compose`, `application.yml` 등 `.gitignore` 파일**: 현재 git 추적 대상이 아니어서 팀원에게 로컬 설정 업데이트 공유가 필요함


  ### 리뷰 반영 (d91f43a)
   - ~~`getRemainingExpiration()`이 만료된 토큰에서 `ExpiredJwtException`을 던져 로그아웃이 실패하는 문제~~ → `catch (ExpiredJwtException)`
    추가, 0 반환하여 블랙리스트 skip + DB 삭제 정상 진행
   - ~~Redis 장애 시 `blacklist()` 예외 전파로 `deleteByUserId()` 미실행~~ → `try-catch`로 감싸고 warn 로그. 예외 전파 차단하여 DB 삭제
   항상 실행
   - ~~Redis 장애 시 `isBlacklisted()` 예외로 모든 인증 요청 HTTP 500~~ → `try-catch`로 감싸고 `false` 반환. Redis 장애 시 요청 허용
   (가용성 우선, 토큰 자연 만료가 안전망)
---

## 테스트 결과

```
BUILD SUCCESSFUL
총 테스트: 전체 통과 (단위 + 통합)
```

## Test plan
- [x] `TokenBlacklistService` 단위 테스트 통과 (blacklist/isBlacklisted)
- [x] `TokenBlacklistService` Testcontainers Redis 연동 테스트 통과 (set → 조회 → TTL 만료)
- [x] `JwtAuthenticationFilter` 블랙리스트 토큰 인증 실패 테스트 통과
- [x] `AuthUsecaseImpl` 로그아웃 시 블랙리스트 등록 테스트 통과
- [x] `CrezipsaApplicationTests` context load 테스트 통과 (Redis mock 환경)
- [x] `./gradlew test` 전체 테스트 통과
- [ ] 로컬 Docker Redis 실행 → 로그인 → 로그아웃 → 같은 토큰 재사용 시 401 확인 (수동 검증)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token blacklist to invalidate logged-out tokens and runtime checks to reject blacklisted tokens during authentication; Redis-backed storage for blacklist entries.

* **Tests**
  * Added unit and integration tests covering blacklist behavior, authentication filter, and Redis interactions (including Testcontainers-based Redis integration).

* **Chores**
  * Added Redis client and Testcontainers testing dependencies; updated repository ignore entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->