### PR TITLE
[Refactor] #59 Refresh Token 로테이션 적용

### DIFF
--- a/src/main/java/tave/crezipsa/crezipsa/application/auth/usecase/AuthUsecaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/auth/usecase/AuthUsecaseImpl.java
@@ -32,7 +32,9 @@ public class AuthUsecaseImpl implements AuthUsecase {
         Auth auth = authRepository.findByUserIdAndRefreshToken(refreshTokenRequest.userId(), refreshTokenRequest.refreshToken()).
                 orElseThrow(() -> new CommonException(ErrorCode.INVALID_REFRESH_TOKEN));
 
-        auth.updateAccessToken(tokenProvider.generateAccessToken(refreshTokenRequest.userId()));
+        String newAccessToken = tokenProvider.generateAccessToken(refreshTokenRequest.userId());
+        String newRefreshToken = tokenProvider.generateRefreshToken(refreshTokenRequest.userId());
+        auth.updateTokens(newAccessToken, newRefreshToken);
 
         return TokenResponse.from(auth);
     }

--- a/src/test/java/tave/crezipsa/crezipsa/application/auth/usecase/AuthUsecaseImplTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/application/auth/usecase/AuthUsecaseImplTest.java
@@ -1,7 +1,11 @@
 package tave.crezipsa.crezipsa.application.auth.usecase;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static tave.crezipsa.crezipsa.fixture.AuthFixture.createAuth;
 
 import java.util.Optional;
 
@@ -13,8 +17,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import tave.crezipsa.crezipsa.application.auth.dto.request.RefreshTokenRequest;
+import tave.crezipsa.crezipsa.application.auth.dto.response.TokenResponse;
 import tave.crezipsa.crezipsa.domain.auth.entity.Auth;
 import tave.crezipsa.crezipsa.domain.auth.repository.AuthRepository;
+import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
+import tave.crezipsa.crezipsa.global.exception.model.CommonException;
+import tave.crezipsa.crezipsa.global.exception.model.JwtAuthenticationException;
 import tave.crezipsa.crezipsa.global.security.JwtTokenProvider;
 import tave.crezipsa.crezipsa.global.security.TokenBlacklistService;
 
@@ -32,6 +41,70 @@ class AuthUsecaseImplTest {
 
 	@InjectMocks
 	private AuthUsecaseImpl authUsecase;
+
+	@Nested
+	@DisplayName("reissueAccessToken")
+	class ReissueAccessToken {
+
+		@Test
+		@DisplayName("유효한 RefreshToken으로 요청하면 AccessToken과 RefreshToken이 모두 갱신된다")
+		void reissueAccessToken_success_rotatesBothTokens() {
+			// Given
+			Long userId = 1L;
+			String oldRefreshToken = "old-refresh-token";
+			String newAccessToken = "new-access-token";
+			String newRefreshToken = "new-refresh-token";
+
+			Auth auth = createAuth(userId, "old-access-token", oldRefreshToken);
+			RefreshTokenRequest request = new RefreshTokenRequest(userId, oldRefreshToken);
+
+			when(authRepository.findByUserIdAndRefreshToken(userId, oldRefreshToken))
+				.thenReturn(Optional.of(auth));
+			when(tokenProvider.generateAccessToken(userId)).thenReturn(newAccessToken);
+			when(tokenProvider.generateRefreshToken(userId)).thenReturn(newRefreshToken);
+
+			// When
+			TokenResponse response = authUsecase.reissueAccessToken(request);
+
+			// Then
+			assertThat(response.accessToken()).isEqualTo(newAccessToken);
+			assertThat(response.refreshToken()).isEqualTo(newRefreshToken);
+		}
+
+		@Test
+		@DisplayName("DB에 존재하지 않는 RefreshToken으로 요청하면 INVALID_REFRESH_TOKEN 예외가 발생한다")
+		void reissueAccessToken_invalidRefreshToken_throwsException() {
+			// Given
+			Long userId = 1L;
+			String invalidRefreshToken = "invalid-refresh-token";
+			RefreshTokenRequest request = new RefreshTokenRequest(userId, invalidRefreshToken);
+
+			when(authRepository.findByUserIdAndRefreshToken(userId, invalidRefreshToken))
+				.thenReturn(Optional.empty());
+
+			// When & Then
+			assertThatThrownBy(() -> authUsecase.reissueAccessToken(request))
+				.isInstanceOf(CommonException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_REFRESH_TOKEN);
+		}
+
+		@Test
+		@DisplayName("만료된 RefreshToken으로 요청하면 JwtAuthenticationException이 발생한다")
+		void reissueAccessToken_expiredRefreshToken_throwsException() {
+			// Given
+			Long userId = 1L;
+			String expiredRefreshToken = "expired-refresh-token";
+			RefreshTokenRequest request = new RefreshTokenRequest(userId, expiredRefreshToken);
+
+			doThrow(new JwtAuthenticationException(ErrorCode.TOKEN_EXPIRED))
+				.when(tokenProvider).validateToken(expiredRefreshToken);
+
+			// When & Then
+			assertThatThrownBy(() -> authUsecase.reissueAccessToken(request))
+				.isInstanceOf(JwtAuthenticationException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.TOKEN_EXPIRED);
+		}
+	}
 
 	@Nested
 	@DisplayName("deleteToken")

--- a/src/test/java/tave/crezipsa/crezipsa/fixture/AuthFixture.java
+++ b/src/test/java/tave/crezipsa/crezipsa/fixture/AuthFixture.java
@@ -1,0 +1,29 @@
+package tave.crezipsa.crezipsa.fixture;
+
+import tave.crezipsa.crezipsa.domain.auth.entity.Auth;
+
+public final class AuthFixture {
+
+	private AuthFixture() {
+	}
+
+	public static Auth createAuth(Long userId) {
+		return Auth.builder()
+			.authId(1L)
+			.userId(userId)
+			.accessToken("access-token-" + userId)
+			.refreshToken("refresh-token-" + userId)
+			.providerUserId("kakao-" + userId)
+			.build();
+	}
+
+	public static Auth createAuth(Long userId, String accessToken, String refreshToken) {
+		return Auth.builder()
+			.authId(1L)
+			.userId(userId)
+			.accessToken(accessToken)
+			.refreshToken(refreshToken)
+			.providerUserId("kakao-" + userId)
+			.build();
+	}
+}


### PR DESCRIPTION
## 📌 작업한 내용
<!-- 이 PR에서 변경된 내용을 간략히 작성해주세요. -->
AccessToken의 만료로 인하여 재발급 요청 시 , RefreshToken의 탈취를 방지하기 위하여 
같이 재발급 되게끔 로테이션을 적용하였습니다.


코드는 클로드코드가 작성하였으나 ,TDD기반으로
case 1)유효한 RefreshToken으로 요청하면 AccessToken과 RefreshToken이 모두 갱신된다
case 2)DB에 존재하지 않는 RefreshToken으로 요청하면 INVALID_REFRESH_TOKEN 예외가 발생한다
의 검증이 통과하는지를 확인하였습니다.
## 🔍 참고 사항
<!-- 리뷰어나 팀원이 참고해야 할 사항이 있으면 적어주세요. -->


## 🖼️ 스크린샷
<!-- UI 변경 사항이 있다면, 관련 스크린샷을 첨부해주세요. -->

<img width="726" height="503" alt="스크린샷 2026-02-24 오후 5 33 09" src="https://github.com/user-attachments/assets/f734c27e-c52d-40fe-8737-c2e0deea6575" />

## 🔗 관련 이슈
<!-- 연관된 이슈를 적어주세요. -->

## ✅ 체크리스트
<!-- PR을 제출하기 전에 확인해야 할 항목들 -->
- [x] 로컬에서 빌드 및 테스트 완료
- [ ] 코드 리뷰 반영 완료
- [ ] 문서화 필요 여부 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced token refresh mechanism now issues both new access and refresh tokens simultaneously, replacing the previous single-token approach.

* **Tests**
  * Added comprehensive test coverage for token refresh functionality, including validation of successful refresh, invalid token handling, and expired token scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->