### PR TITLE
[refactor] #62 커뮤니티 조회 API Redis 캐싱 적용 및 성능 검증

### DIFF
--- a/.github/workflows/dev-cicd.yml
+++ b/.github/workflows/dev-cicd.yml
@@ -1,4 +1,4 @@
-계획name: CI/CD Dev
+name: CI/CD Dev
 
 on:
   push:

--- a/.github/workflows/dev-cicd.yml
+++ b/.github/workflows/dev-cicd.yml
@@ -1,4 +1,4 @@
-name: CI/CD Dev
+계획name: CI/CD Dev
 
 on:
   push:

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
 
     //redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
 
     //XML <-> 자바 객체 변환
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:4.0.2'

--- a/k6/debug_test.js
+++ b/k6/debug_test.js
@@ -1,0 +1,25 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+export const options = {
+  vus: 1,
+  iterations: 1,
+};
+
+const BASE_URL = 'http://localhost:8080';
+const TOKEN = __ENV.TOKEN;
+
+export default function () {
+  // 토큰 값 확인
+  console.log(`TOKEN length: ${TOKEN ? TOKEN.length : 'null'}`);
+  console.log(`TOKEN first 20: ${TOKEN ? TOKEN.substring(0, 20) : 'null'}`);
+  console.log(`TOKEN last 10: ${TOKEN ? TOKEN.substring(TOKEN.length - 10) : 'null'}`);
+
+  const headerValue = `Bearer ${TOKEN}`;
+  console.log(`Header length: ${headerValue.length}`);
+
+  const headers = { 'Authorization': headerValue };
+  const res = http.get(`${BASE_URL}/api/community`, { headers });
+  console.log(`status: ${res.status}`);
+  console.log(`body: ${res.body.substring(0, 300)}`);
+}

--- a/k6/load_test.js
+++ b/k6/load_test.js
@@ -1,0 +1,83 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend, Rate, Counter } from 'k6/metrics';
+import { open } from 'k6/experimental/fs';
+
+// 커스텀 메트릭
+const listLatency = new Trend('community_list_duration', true);
+const detailLatency = new Trend('community_detail_duration', true);
+const commentLatency = new Trend('comment_list_duration', true);
+const filterLatency = new Trend('community_filter_duration', true);
+const errorRate = new Rate('errors');
+const requestCount = new Counter('total_requests');
+
+export const options = {
+  stages: [
+    { duration: '10s', target: 50 },
+    { duration: '30s', target: 100 },
+    { duration: '10s', target: 0 },
+  ],
+  thresholds: {
+    http_req_duration: ['p(95)<500'],
+    errors: ['rate<0.01'],
+  },
+};
+
+const BASE_URL = 'http://localhost:8080';
+const TOKEN = __ENV.TOKEN;
+const COMMUNITY_IDS = [1, 3, 4, 5, 6, 8, 10, 11];
+const FIELDS = ['RECOMMEND', 'TIP', 'COLLAB'];
+
+const headers = {
+  'Authorization': `Bearer ${TOKEN}`,
+  'Content-Type': 'application/json',
+};
+
+export default function () {
+  const communityId = COMMUNITY_IDS[Math.floor(Math.random() * COMMUNITY_IDS.length)];
+  const field = FIELDS[Math.floor(Math.random() * FIELDS.length)];
+
+  // 1. 전체 목록 조회
+  {
+    const res = http.get(`${BASE_URL}/api/community`, { headers });
+    listLatency.add(res.timings.duration);
+    requestCount.add(1);
+    const ok = check(res, { 'community list 200': (r) => r.status === 200 });
+    if (!ok) errorRate.add(1); else errorRate.add(0);
+  }
+
+  sleep(0.1);
+
+  // 2. 필드별 목록 조회
+  {
+    const res = http.get(`${BASE_URL}/api/community/filter?field=${field}`, { headers });
+    filterLatency.add(res.timings.duration);
+    requestCount.add(1);
+    const ok = check(res, { 'filter list 200': (r) => r.status === 200 });
+    if (!ok) errorRate.add(1); else errorRate.add(0);
+  }
+
+  sleep(0.1);
+
+  // 3. 커뮤니티 상세 조회
+  {
+    const res = http.get(`${BASE_URL}/api/community/${communityId}`, { headers });
+    detailLatency.add(res.timings.duration);
+    requestCount.add(1);
+    const ok = check(res, { 'community detail 200': (r) => r.status === 200 });
+    if (!ok) errorRate.add(1); else errorRate.add(0);
+  }
+
+  sleep(0.1);
+
+  // 4. 댓글 목록 조회
+  {
+    const res = http.get(`${BASE_URL}/api/comment/community/${communityId}`, { headers });
+    commentLatency.add(res.timings.duration);
+    requestCount.add(1);
+    const ok = check(res, { 'comment list 200': (r) => r.status === 200 });
+    if (!ok) errorRate.add(1); else errorRate.add(0);
+  }
+
+  sleep(0.2);
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/cache/CommunityCacheService.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/cache/CommunityCacheService.java
@@ -1,0 +1,184 @@
+package tave.crezipsa.crezipsa.application.community.cache;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import tave.crezipsa.crezipsa.application.community.dto.cache.CommentCacheDto;
+import tave.crezipsa.crezipsa.application.community.dto.cache.CommunityDetailCacheDto;
+import tave.crezipsa.crezipsa.application.community.dto.cache.CommunitySummaryCacheDto;
+import tave.crezipsa.crezipsa.application.community.dto.response.WriterResponse;
+import tave.crezipsa.crezipsa.domain.community.domain.Comment;
+import tave.crezipsa.crezipsa.domain.community.domain.Community;
+import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
+import tave.crezipsa.crezipsa.domain.community.repository.CommentRepository;
+import tave.crezipsa.crezipsa.domain.community.repository.CommunityRepository;
+import tave.crezipsa.crezipsa.domain.user.entity.User;
+import tave.crezipsa.crezipsa.domain.user.repository.UserRepository;
+import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
+import tave.crezipsa.crezipsa.global.exception.model.CommonException;
+
+@Service
+@RequiredArgsConstructor
+public class CommunityCacheService {
+
+	private final CommunityRepository communityRepository;
+	private final CommentRepository commentRepository;
+	private final UserRepository userRepository;
+
+	@Cacheable(value = "community-list", key = "'all'")
+	@Transactional(readOnly = true)
+	public List<CommunitySummaryCacheDto> getAllCommunitiesCache() {
+		List<Community> communities = communityRepository.findAll();
+		Map<Long, Long> commentCounts = loadCommentCounts(communities);
+
+		return communities.stream()
+			.map(c -> CommunitySummaryCacheDto.from(
+				c,
+				c.getLikeCount(),
+				commentCounts.getOrDefault(c.getCommunityId(), 0L)
+			))
+			.toList();
+	}
+
+	@Cacheable(value = "community-list-by-field", key = "#field.name()")
+	@Transactional(readOnly = true)
+	public List<CommunitySummaryCacheDto> getCommunitiesByFieldCache(CommunityField field) {
+		List<Community> communities = communityRepository.findByField(field);
+		Map<Long, Long> commentCounts = loadCommentCounts(communities);
+
+		return communities.stream()
+			.map(c -> CommunitySummaryCacheDto.from(
+				c,
+				c.getLikeCount(),
+				commentCounts.getOrDefault(c.getCommunityId(), 0L)
+			))
+			.toList();
+	}
+
+	@Cacheable(value = "community-detail", key = "#communityId")
+	@Transactional(readOnly = true)
+	public CommunityDetailCacheDto getCommunityDetailCache(Long communityId) {
+		Community community = communityRepository.findById(communityId)
+			.orElseThrow(() -> new CommonException(ErrorCode.COMMUNITY_NOT_FOUND));
+
+		User writerUser = userRepository.findById(community.getWriterId())
+			.orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
+
+		long commentCount = commentRepository.countByCommunityId(communityId);
+		List<CommentCacheDto> comments = buildCommentCacheDtos(communityId);
+
+		return CommunityDetailCacheDto.from(community, WriterResponse.from(writerUser), commentCount, comments);
+	}
+
+	@Cacheable(value = "comment-list", key = "#communityId")
+	@Transactional(readOnly = true)
+	public List<CommentCacheDto> getCommentsCache(Long communityId) {
+		return buildCommentCacheDtos(communityId);
+	}
+
+	// ===== 캐시 무효화 =====
+
+	@Caching(evict = {
+		@CacheEvict(value = "community-list", allEntries = true),
+		@CacheEvict(value = "community-list-by-field", allEntries = true)
+	})
+	public void evictCommunityLists() {}
+
+	@Caching(evict = {
+		@CacheEvict(value = "community-list", allEntries = true),
+		@CacheEvict(value = "community-list-by-field", allEntries = true),
+		@CacheEvict(value = "community-detail", key = "#communityId")
+	})
+	public void evictCommunityAll(Long communityId) {}
+
+	@Caching(evict = {
+		@CacheEvict(value = "community-list", allEntries = true),
+		@CacheEvict(value = "community-list-by-field", allEntries = true),
+		@CacheEvict(value = "community-detail", key = "#communityId"),
+		@CacheEvict(value = "comment-list", key = "#communityId")
+	})
+	public void evictCommunityAndComments(Long communityId) {}
+
+	@Caching(evict = {
+		@CacheEvict(value = "community-detail", key = "#communityId"),
+		@CacheEvict(value = "comment-list", key = "#communityId")
+	})
+	public void evictCommentsAndDetail(Long communityId) {}
+
+	// ===== 내부 헬퍼 =====
+
+	private List<CommentCacheDto> buildCommentCacheDtos(Long communityId) {
+		List<Comment> allComments = commentRepository.findByCommunityId(communityId);
+		if (allComments.isEmpty()) {
+			return List.of();
+		}
+
+		Set<Long> writerIds = allComments.stream()
+			.map(Comment::getUserId)
+			.collect(Collectors.toSet());
+
+		Map<Long, User> writerMap = userRepository.findAllById(writerIds).stream()
+			.collect(Collectors.toMap(User::getUserId, u -> u));
+
+		Map<Long, List<Comment>> childrenByParentId = allComments.stream()
+			.filter(c -> c.getParentId() != null)
+			.collect(Collectors.groupingBy(Comment::getParentId));
+
+		return allComments.stream()
+			.filter(c -> c.getParentId() == null)
+			.sorted(Comparator.comparing(Comment::getCreatedAt))
+			.map(root -> toCommentCacheTree(root, childrenByParentId, writerMap))
+			.toList();
+	}
+
+	private CommentCacheDto toCommentCacheTree(
+		Comment comment,
+		Map<Long, List<Comment>> childrenByParentId,
+		Map<Long, User> writerMap
+	) {
+		User writer = writerMap.get(comment.getUserId());
+		if (writer == null) {
+			throw new CommonException(ErrorCode.USER_NOT_FOUND);
+		}
+
+		List<CommentCacheDto> replies = childrenByParentId
+			.getOrDefault(comment.getCommentId(), List.of())
+			.stream()
+			.sorted(Comparator.comparing(Comment::getCreatedAt))
+			.map(child -> toCommentCacheTree(child, childrenByParentId, writerMap))
+			.toList();
+
+		return new CommentCacheDto(
+			comment.getCommentId(),
+			comment.getCommunityId(),
+			comment.getParentId(),
+			comment.getUserId(),
+			WriterResponse.from(writer),
+			comment.isDeleted(),
+			comment.getContent(),
+			comment.getCreatedAt(),
+			replies
+		);
+	}
+
+	private Map<Long, Long> loadCommentCounts(List<Community> communities) {
+		if (communities == null || communities.isEmpty()) {
+			return Collections.emptyMap();
+		}
+		List<Long> communityIds = communities.stream()
+			.map(Community::getCommunityId)
+			.toList();
+		return commentRepository.countByCommunityIds(communityIds);
+	}
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/cache/CommunityCacheService.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/cache/CommunityCacheService.java
@@ -1,5 +1,6 @@
 package tave.crezipsa.crezipsa.application.community.cache;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -48,7 +49,7 @@ public class CommunityCacheService {
 				c.getLikeCount(),
 				commentCounts.getOrDefault(c.getCommunityId(), 0L)
 			))
-			.toList();
+			.collect(Collectors.toList());
 	}
 
 	@Cacheable(value = "community-list-by-field", key = "#field.name()")
@@ -63,7 +64,7 @@ public class CommunityCacheService {
 				c.getLikeCount(),
 				commentCounts.getOrDefault(c.getCommunityId(), 0L)
 			))
-			.toList();
+			.collect(Collectors.toList());
 	}
 
 	@Cacheable(value = "community-detail", key = "#communityId")
@@ -121,7 +122,7 @@ public class CommunityCacheService {
 	private List<CommentCacheDto> buildCommentCacheDtos(Long communityId) {
 		List<Comment> allComments = commentRepository.findByCommunityId(communityId);
 		if (allComments.isEmpty()) {
-			return List.of();
+			return new ArrayList<>();
 		}
 
 		Set<Long> writerIds = allComments.stream()
@@ -139,7 +140,7 @@ public class CommunityCacheService {
 			.filter(c -> c.getParentId() == null)
 			.sorted(Comparator.comparing(Comment::getCreatedAt))
 			.map(root -> toCommentCacheTree(root, childrenByParentId, writerMap))
-			.toList();
+			.collect(Collectors.toList());
 	}
 
 	private CommentCacheDto toCommentCacheTree(
@@ -153,11 +154,11 @@ public class CommunityCacheService {
 		}
 
 		List<CommentCacheDto> replies = childrenByParentId
-			.getOrDefault(comment.getCommentId(), List.of())
+			.getOrDefault(comment.getCommentId(), Collections.emptyList())
 			.stream()
 			.sorted(Comparator.comparing(Comment::getCreatedAt))
 			.map(child -> toCommentCacheTree(child, childrenByParentId, writerMap))
-			.toList();
+			.collect(Collectors.toList());
 
 		return new CommentCacheDto(
 			comment.getCommentId(),
@@ -178,7 +179,7 @@ public class CommunityCacheService {
 		}
 		List<Long> communityIds = communities.stream()
 			.map(Community::getCommunityId)
-			.toList();
+			.collect(Collectors.toList());
 		return commentRepository.countByCommunityIds(communityIds);
 	}
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/dto/cache/CommentCacheDto.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/dto/cache/CommentCacheDto.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import tave.crezipsa.crezipsa.application.community.dto.response.CommentResponse;
 import tave.crezipsa.crezipsa.application.community.dto.response.WriterResponse;
-import tave.crezipsa.crezipsa.application.community.usecase.LikeUseCaseImpl;
+import tave.crezipsa.crezipsa.global.common.TimeUtils;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.WRAPPER_ARRAY)
 public record CommentCacheDto(
@@ -36,7 +36,7 @@ public record CommentCacheDto(
 			deleted,
 			content,
 			createdAt,
-			LikeUseCaseImpl.convertToRelativeTime(createdAt),
+			TimeUtils.convertToRelativeTime(createdAt),
 			replyResponses
 		);
 	}

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/dto/cache/CommentCacheDto.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/dto/cache/CommentCacheDto.java
@@ -1,0 +1,40 @@
+package tave.crezipsa.crezipsa.application.community.dto.cache;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import tave.crezipsa.crezipsa.application.community.dto.response.CommentResponse;
+import tave.crezipsa.crezipsa.application.community.dto.response.WriterResponse;
+import tave.crezipsa.crezipsa.application.community.usecase.LikeUseCaseImpl;
+
+public record CommentCacheDto(
+	Long commentId,
+	Long communityId,
+	Long parentId,
+	Long userId,
+	WriterResponse writer,
+	boolean deleted,
+	String content,
+	LocalDateTime createdAt,
+	List<CommentCacheDto> replies
+) {
+	public CommentResponse toResponse(Long viewerId) {
+		boolean isWriter = viewerId != null && viewerId.equals(userId);
+		List<CommentResponse> replyResponses = replies.stream()
+			.map(r -> r.toResponse(viewerId))
+			.toList();
+
+		return new CommentResponse(
+			commentId,
+			communityId,
+			parentId,
+			writer,
+			isWriter,
+			deleted,
+			content,
+			createdAt,
+			LikeUseCaseImpl.convertToRelativeTime(createdAt),
+			replyResponses
+		);
+	}
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/dto/cache/CommentCacheDto.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/dto/cache/CommentCacheDto.java
@@ -3,10 +3,13 @@ package tave.crezipsa.crezipsa.application.community.dto.cache;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 import tave.crezipsa.crezipsa.application.community.dto.response.CommentResponse;
 import tave.crezipsa.crezipsa.application.community.dto.response.WriterResponse;
 import tave.crezipsa.crezipsa.application.community.usecase.LikeUseCaseImpl;
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.WRAPPER_ARRAY)
 public record CommentCacheDto(
 	Long commentId,
 	Long communityId,

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/dto/cache/CommunityDetailCacheDto.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/dto/cache/CommunityDetailCacheDto.java
@@ -8,8 +8,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import tave.crezipsa.crezipsa.application.community.dto.response.CommentResponse;
 import tave.crezipsa.crezipsa.application.community.dto.response.CommunityDetailResponse;
 import tave.crezipsa.crezipsa.application.community.dto.response.WriterResponse;
-import tave.crezipsa.crezipsa.application.community.usecase.LikeUseCaseImpl;
 import tave.crezipsa.crezipsa.domain.community.domain.Community;
+import tave.crezipsa.crezipsa.global.common.TimeUtils;
 import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.WRAPPER_ARRAY)
@@ -59,7 +59,7 @@ public record CommunityDetailCacheDto(
 			isLiked,
 			likeCount,
 			commentCount,
-			LikeUseCaseImpl.convertToRelativeTime(createdAt),
+			TimeUtils.convertToRelativeTime(createdAt),
 			comments
 		);
 	}

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/dto/cache/CommunityDetailCacheDto.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/dto/cache/CommunityDetailCacheDto.java
@@ -3,6 +3,8 @@ package tave.crezipsa.crezipsa.application.community.dto.cache;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 import tave.crezipsa.crezipsa.application.community.dto.response.CommentResponse;
 import tave.crezipsa.crezipsa.application.community.dto.response.CommunityDetailResponse;
 import tave.crezipsa.crezipsa.application.community.dto.response.WriterResponse;
@@ -10,6 +12,7 @@ import tave.crezipsa.crezipsa.application.community.usecase.LikeUseCaseImpl;
 import tave.crezipsa.crezipsa.domain.community.domain.Community;
 import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.WRAPPER_ARRAY)
 public record CommunityDetailCacheDto(
 	Long communityId,
 	Long writerId,

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/dto/cache/CommunityDetailCacheDto.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/dto/cache/CommunityDetailCacheDto.java
@@ -1,0 +1,63 @@
+package tave.crezipsa.crezipsa.application.community.dto.cache;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import tave.crezipsa.crezipsa.application.community.dto.response.CommentResponse;
+import tave.crezipsa.crezipsa.application.community.dto.response.CommunityDetailResponse;
+import tave.crezipsa.crezipsa.application.community.dto.response.WriterResponse;
+import tave.crezipsa.crezipsa.application.community.usecase.LikeUseCaseImpl;
+import tave.crezipsa.crezipsa.domain.community.domain.Community;
+import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
+
+public record CommunityDetailCacheDto(
+	Long communityId,
+	Long writerId,
+	String title,
+	String content,
+	CommunityField field,
+	List<String> imageUrls,
+	WriterResponse writer,
+	long likeCount,
+	long commentCount,
+	LocalDateTime createdAt,
+	List<CommentCacheDto> comments
+) {
+	public static CommunityDetailCacheDto from(
+		Community community,
+		WriterResponse writer,
+		long commentCount,
+		List<CommentCacheDto> comments
+	) {
+		return new CommunityDetailCacheDto(
+			community.getCommunityId(),
+			community.getWriterId(),
+			community.getTitle(),
+			community.getContent(),
+			community.getField(),
+			community.getImageUrls(),
+			writer,
+			community.getLikeCount(),
+			commentCount,
+			community.getCreatedAt(),
+			comments
+		);
+	}
+
+	public CommunityDetailResponse toResponse(boolean isWriter, boolean isLiked, List<CommentResponse> comments) {
+		return new CommunityDetailResponse(
+			communityId,
+			title,
+			content,
+			field,
+			imageUrls,
+			writer,
+			isWriter,
+			isLiked,
+			likeCount,
+			commentCount,
+			LikeUseCaseImpl.convertToRelativeTime(createdAt),
+			comments
+		);
+	}
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/dto/cache/CommunitySummaryCacheDto.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/dto/cache/CommunitySummaryCacheDto.java
@@ -2,11 +2,14 @@ package tave.crezipsa.crezipsa.application.community.dto.cache;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
 import tave.crezipsa.crezipsa.application.community.dto.response.CommunitySummaryResponse;
 import tave.crezipsa.crezipsa.application.community.usecase.LikeUseCaseImpl;
 import tave.crezipsa.crezipsa.domain.community.domain.Community;
 import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.WRAPPER_ARRAY)
 public record CommunitySummaryCacheDto(
 	Long communityId,
 	CommunityField field,

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/dto/cache/CommunitySummaryCacheDto.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/dto/cache/CommunitySummaryCacheDto.java
@@ -1,0 +1,49 @@
+package tave.crezipsa.crezipsa.application.community.dto.cache;
+
+import java.time.LocalDateTime;
+
+import tave.crezipsa.crezipsa.application.community.dto.response.CommunitySummaryResponse;
+import tave.crezipsa.crezipsa.application.community.usecase.LikeUseCaseImpl;
+import tave.crezipsa.crezipsa.domain.community.domain.Community;
+import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
+
+public record CommunitySummaryCacheDto(
+	Long communityId,
+	CommunityField field,
+	String title,
+	String contentPreview,
+	long likeCount,
+	long commentCount,
+	LocalDateTime createdAt,
+	String thumbnailUrl
+) {
+	public static CommunitySummaryCacheDto from(Community community, long likeCount, long commentCount) {
+		String thumbnail = (community.getImageUrls() != null && !community.getImageUrls().isEmpty())
+			? community.getImageUrls().get(0)
+			: null;
+
+		return new CommunitySummaryCacheDto(
+			community.getCommunityId(),
+			community.getField(),
+			community.getTitle(),
+			LikeUseCaseImpl.preview(community.getContent()),
+			likeCount,
+			commentCount,
+			community.getCreatedAt(),
+			thumbnail
+		);
+	}
+
+	public CommunitySummaryResponse toResponse() {
+		return new CommunitySummaryResponse(
+			communityId,
+			field,
+			title,
+			contentPreview,
+			likeCount,
+			commentCount,
+			LikeUseCaseImpl.convertToRelativeTime(createdAt),
+			thumbnailUrl
+		);
+	}
+}

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/dto/cache/CommunitySummaryCacheDto.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/dto/cache/CommunitySummaryCacheDto.java
@@ -5,8 +5,8 @@ import java.time.LocalDateTime;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import tave.crezipsa.crezipsa.application.community.dto.response.CommunitySummaryResponse;
-import tave.crezipsa.crezipsa.application.community.usecase.LikeUseCaseImpl;
 import tave.crezipsa.crezipsa.domain.community.domain.Community;
+import tave.crezipsa.crezipsa.global.common.TimeUtils;
 import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.WRAPPER_ARRAY)
@@ -29,7 +29,7 @@ public record CommunitySummaryCacheDto(
 			community.getCommunityId(),
 			community.getField(),
 			community.getTitle(),
-			LikeUseCaseImpl.preview(community.getContent()),
+			TimeUtils.preview(community.getContent()),
 			likeCount,
 			commentCount,
 			community.getCreatedAt(),
@@ -45,7 +45,7 @@ public record CommunitySummaryCacheDto(
 			contentPreview,
 			likeCount,
 			commentCount,
-			LikeUseCaseImpl.convertToRelativeTime(createdAt),
+			TimeUtils.convertToRelativeTime(createdAt),
 			thumbnailUrl
 		);
 	}

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/CommunityDetailResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/CommunityDetailResponse.java
@@ -1,11 +1,10 @@
 package tave.crezipsa.crezipsa.application.community.dto.response;
 
-import static tave.crezipsa.crezipsa.application.community.usecase.LikeUseCaseImpl.*;
-
 import java.time.LocalDateTime;
 import java.util.List;
 
 import tave.crezipsa.crezipsa.domain.community.domain.Community;
+import tave.crezipsa.crezipsa.global.common.TimeUtils;
 import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
 
 public record CommunityDetailResponse(
@@ -42,7 +41,7 @@ public record CommunityDetailResponse(
 			isLiked,
 			community.getLikeCount(),
 			commentCount,
-			convertToRelativeTime(community.getCreatedAt()),
+			TimeUtils.convertToRelativeTime(community.getCreatedAt()),
 			comments
 		);
 	}

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/CommunitySummaryResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/CommunitySummaryResponse.java
@@ -1,7 +1,7 @@
 package tave.crezipsa.crezipsa.application.community.dto.response;
 
-import tave.crezipsa.crezipsa.application.community.usecase.LikeUseCaseImpl;
 import tave.crezipsa.crezipsa.domain.community.domain.Community;
+import tave.crezipsa.crezipsa.global.common.TimeUtils;
 import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
 
 public record CommunitySummaryResponse(
@@ -28,10 +28,10 @@ public record CommunitySummaryResponse(
 			community.getCommunityId(),
 			community.getField(),
 			community.getTitle(),
-			LikeUseCaseImpl.preview(community.getContent()),
+			TimeUtils.preview(community.getContent()),
 			likeCount,
 			commentCount,
-			LikeUseCaseImpl.convertToRelativeTime(community.getCreatedAt()),
+			TimeUtils.convertToRelativeTime(community.getCreatedAt()),
 			thumbnail
 		);
 	}

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/MyCommentResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/MyCommentResponse.java
@@ -1,8 +1,7 @@
 package tave.crezipsa.crezipsa.application.community.dto.response;
 
-import static tave.crezipsa.crezipsa.application.community.usecase.LikeUseCaseImpl.*;
-
 import tave.crezipsa.crezipsa.domain.community.domain.Community;
+import tave.crezipsa.crezipsa.global.common.TimeUtils;
 import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
 
 public record MyCommentResponse(
@@ -18,8 +17,8 @@ public record MyCommentResponse(
 			community.getCommunityId(),
 			community.getField(),
 			community.getTitle(),
-			preview(community.getContent()),
-			convertToRelativeTime(community.getCreatedAt())
+			TimeUtils.preview(community.getContent()),
+			TimeUtils.convertToRelativeTime(community.getCreatedAt())
 		);
 
 	}

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/MyCommunityResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/MyCommunityResponse.java
@@ -1,9 +1,8 @@
 package tave.crezipsa.crezipsa.application.community.dto.response;
 
-import static tave.crezipsa.crezipsa.application.community.usecase.LikeUseCaseImpl.*;
-
-import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
 import tave.crezipsa.crezipsa.domain.community.domain.Community;
+import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
+import tave.crezipsa.crezipsa.global.common.TimeUtils;
 
 public record MyCommunityResponse(
 	Long communityId,
@@ -29,10 +28,10 @@ public record MyCommunityResponse(
 			community.getCommunityId(),
 			community.getField(),
 			community.getTitle(),
-			preview(community.getContent()),
+			TimeUtils.preview(community.getContent()),
 			likeCount,
 			commentCount,
-			convertToRelativeTime(community.getCreatedAt()),
+			TimeUtils.convertToRelativeTime(community.getCreatedAt()),
 			thumbnail
 		);
 	}

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/MyLikedCommunityResponse.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/dto/response/MyLikedCommunityResponse.java
@@ -1,7 +1,7 @@
 package tave.crezipsa.crezipsa.application.community.dto.response;
 
-import static tave.crezipsa.crezipsa.application.community.usecase.LikeUseCaseImpl.*;
 import tave.crezipsa.crezipsa.domain.community.domain.Community;
+import tave.crezipsa.crezipsa.global.common.TimeUtils;
 import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
 
 public record MyLikedCommunityResponse(
@@ -28,10 +28,10 @@ public record MyLikedCommunityResponse(
 			community.getCommunityId(),
 			community.getField(),
 			community.getTitle(),
-			preview(community.getContent()),
+			TimeUtils.preview(community.getContent()),
 			likeCount,
 			commentCount,
-			convertToRelativeTime(community.getCreatedAt()),
+			TimeUtils.convertToRelativeTime(community.getCreatedAt()),
 			thumbnail
 		);
 	}

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/CommentUseCaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/CommentUseCaseImpl.java
@@ -1,7 +1,5 @@
 package tave.crezipsa.crezipsa.application.community.usecase;
 
-import static tave.crezipsa.crezipsa.application.community.usecase.LikeUseCaseImpl.*;
-
 import java.util.List;
 
 import org.springframework.data.domain.Page;
@@ -24,6 +22,7 @@ import tave.crezipsa.crezipsa.domain.community.repository.CommentRepository;
 import tave.crezipsa.crezipsa.domain.community.repository.CommunityRepository;
 import tave.crezipsa.crezipsa.domain.user.entity.User;
 import tave.crezipsa.crezipsa.domain.user.repository.UserRepository;
+import tave.crezipsa.crezipsa.global.common.TimeUtils;
 import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
 import tave.crezipsa.crezipsa.global.exception.model.CommonException;
 
@@ -51,7 +50,7 @@ public class CommentUseCaseImpl implements CommentUsecase {
 
 		Comment saved = commentRepository.save(Comment.create(communityId, userId, request.content(), parentId));
 		User writer = findUserOrThrow(userId);
-		String relativeTime = convertToRelativeTime(saved.getCreatedAt());
+		String relativeTime = TimeUtils.convertToRelativeTime(saved.getCreatedAt());
 
 		communityCacheService.evictCommentsAndDetail(communityId);
 		return commentMapper.toCommentResponse(saved, writer, true, relativeTime, List.of());
@@ -67,7 +66,7 @@ public class CommentUseCaseImpl implements CommentUsecase {
 
 		comment.update(request.content());
 		User writer = findUserOrThrow(userId);
-		String relativeTime = convertToRelativeTime(comment.getCreatedAt());
+		String relativeTime = TimeUtils.convertToRelativeTime(comment.getCreatedAt());
 
 		communityCacheService.evictCommentsAndDetail(comment.getCommunityId());
 		return commentMapper.toCommentResponse(comment, writer, true, relativeTime, List.of());

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/CommentUseCaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/CommentUseCaseImpl.java
@@ -23,6 +23,7 @@ import tave.crezipsa.crezipsa.domain.community.repository.CommunityRepository;
 import tave.crezipsa.crezipsa.domain.user.entity.User;
 import tave.crezipsa.crezipsa.domain.user.repository.UserRepository;
 import tave.crezipsa.crezipsa.global.common.TimeUtils;
+import tave.crezipsa.crezipsa.global.common.TransactionUtils;
 import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
 import tave.crezipsa.crezipsa.global.exception.model.CommonException;
 
@@ -52,7 +53,7 @@ public class CommentUseCaseImpl implements CommentUsecase {
 		User writer = findUserOrThrow(userId);
 		String relativeTime = TimeUtils.convertToRelativeTime(saved.getCreatedAt());
 
-		communityCacheService.evictCommentsAndDetail(communityId);
+		TransactionUtils.afterCommit(() -> communityCacheService.evictCommentsAndDetail(communityId));
 		return commentMapper.toCommentResponse(saved, writer, true, relativeTime, List.of());
 	}
 
@@ -88,7 +89,7 @@ public class CommentUseCaseImpl implements CommentUsecase {
 			commentRepository.delete(comment);
 		}
 
-		communityCacheService.evictCommentsAndDetail(communityId);
+		TransactionUtils.afterCommit(() -> communityCacheService.evictCommentsAndDetail(communityId));
 	}
 
 	@Override

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/CommentUseCaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/CommentUseCaseImpl.java
@@ -2,12 +2,7 @@ package tave.crezipsa.crezipsa.application.community.usecase;
 
 import static tave.crezipsa.crezipsa.application.community.usecase.LikeUseCaseImpl.*;
 
-import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -16,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import tave.crezipsa.crezipsa.application.community.cache.CommunityCacheService;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommentCreateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommentUpdateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.response.CommentResponse;
@@ -34,16 +30,16 @@ import tave.crezipsa.crezipsa.global.exception.model.CommonException;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class CommentUseCaseImpl implements  CommentUsecase {
+public class CommentUseCaseImpl implements CommentUsecase {
 
 	private final CommentRepository commentRepository;
 	private final CommunityRepository communityRepository;
 	private final UserRepository userRepository;
 	private final CommentMapper commentMapper;
+	private final CommunityCacheService communityCacheService;
 
 	@Override
 	public CommentResponse createComment(Long communityId, Long userId, CommentCreateRequest request) {
-
 		findCommunityOrThrow(communityId);
 		Long parentId = request.parentId();
 
@@ -55,15 +51,14 @@ public class CommentUseCaseImpl implements  CommentUsecase {
 
 		Comment saved = commentRepository.save(Comment.create(communityId, userId, request.content(), parentId));
 		User writer = findUserOrThrow(userId);
-		boolean isWriter = true;
 		String relativeTime = convertToRelativeTime(saved.getCreatedAt());
 
-		return commentMapper.toCommentResponse(saved, writer,isWriter, relativeTime, List.of());
+		communityCacheService.evictCommentsAndDetail(communityId);
+		return commentMapper.toCommentResponse(saved, writer, true, relativeTime, List.of());
 	}
 
 	@Override
 	public CommentResponse updateComment(Long commentId, Long userId, CommentUpdateRequest request) {
-
 		Comment comment = findCommentOrThrow(commentId);
 
 		if (!comment.getUserId().equals(userId)) {
@@ -72,97 +67,52 @@ public class CommentUseCaseImpl implements  CommentUsecase {
 
 		comment.update(request.content());
 		User writer = findUserOrThrow(userId);
-		boolean isWriter = true;
 		String relativeTime = convertToRelativeTime(comment.getCreatedAt());
 
-		return commentMapper.toCommentResponse(comment, writer,isWriter, relativeTime, List.of());
+		communityCacheService.evictCommentsAndDetail(comment.getCommunityId());
+		return commentMapper.toCommentResponse(comment, writer, true, relativeTime, List.of());
 	}
 
 	@Override
 	public void deleteComment(Long commentId, Long userId) {
-
 		Comment comment = findCommentOrThrow(commentId);
 
 		if (!comment.getUserId().equals(userId)) {
 			throw new CommonException(ErrorCode.UNAUTHORIZED_COMMENT);
 		}
 
+		Long communityId = comment.getCommunityId();
+
 		if (comment.getParentId() == null) {
 			comment.softDelete();
 		} else {
 			commentRepository.delete(comment);
 		}
+
+		communityCacheService.evictCommentsAndDetail(communityId);
 	}
 
 	@Override
+	@Transactional(readOnly = true)
 	public List<CommentResponse> getComments(Long communityId, Long userId) {
 		findCommunityOrThrow(communityId);
 
-		List<Comment> allComments = commentRepository.findByCommunityId(communityId);
-		if (allComments.isEmpty()) {
-			return List.of();
-		}
-
-		Set<Long> writerIds = allComments.stream()
-			.map(Comment::getUserId)
-			.collect(Collectors.toSet());
-
-		List<User> writers = userRepository.findAllById(writerIds);
-
-		Map<Long, User> writerMap = writers.stream()
-			.collect(Collectors.toMap(User::getUserId, u -> u));
-
-		Map<Long, List<Comment>> childrenByParentId = allComments.stream()
-			.filter(c -> c.getParentId() != null)
-			.collect(Collectors.groupingBy(Comment::getParentId));
-
-		List<Comment> rootComments = allComments.stream()
-			.filter(c -> c.getParentId() == null)
-			.sorted(Comparator.comparing(Comment::getCreatedAt))
+		return communityCacheService.getCommentsCache(communityId).stream()
+			.map(dto -> dto.toResponse(userId))
 			.toList();
-
-		return rootComments.stream()
-			.map(root -> toResponseTree(root, childrenByParentId, writerMap, userId))
-			.toList();
-
 	}
 
 	@Override
 	public List<MyCommentResponse> getMyComments(Long userId, CommunityField field, int page, int size) {
 		Pageable pageable = PageRequest.of(page, size);
 
-
 		return commentRepository
 			.findMyCommentsByCommunityField(userId, field, pageable)
 			.stream()
-			.map(MyCommentResponse::of) // Comment 기준
+			.map(MyCommentResponse::of)
 			.toList();
 	}
 
-	private CommentResponse toResponseTree(Comment comment, Map<Long, List<Comment>> childrenByParentId,
-		Map<Long, User> writerMap, Long viewerId) {
-		User writer = writerMap.get(comment.getUserId());
-		if (writer == null) {
-			throw new CommonException(ErrorCode.USER_NOT_FOUND);
-		}
-
-		// 나를 부모로 가진 자식 댓글들
-		List<Comment> children = childrenByParentId.getOrDefault(comment.getCommentId(), List.of());
-
-		// 자식들도 재귀적으로 CommentResponse로 변환
-		List<CommentResponse> replyResponses = children.stream()
-			.sorted(Comparator.comparing(Comment::getCreatedAt)) // 대댓글도 정렬(선택)
-			.map(child -> toResponseTree(child, childrenByParentId, writerMap, viewerId))
-			.toList();
-
-		boolean isWriter = viewerId != null && Objects.equals(comment.getUserId(), viewerId);
-		String relativeTime = convertToRelativeTime(comment.getCreatedAt());
-
-		// Mapper는 변환만
-		return commentMapper.toCommentResponse(comment, writer,isWriter, relativeTime, replyResponses);
-	}
-
-	// 검증 로직의 반복이 잦아 헬퍼 메소드로 분리
 	private User findUserOrThrow(Long userId) {
 		return userRepository.findById(userId)
 			.orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
@@ -189,5 +139,4 @@ public class CommentUseCaseImpl implements  CommentUsecase {
 			throw new CommonException(ErrorCode.INVALID_PARENT_COMMUNITY);
 		}
 	}
-
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/CommunityUseCaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/CommunityUseCaseImpl.java
@@ -1,8 +1,6 @@
 package tave.crezipsa.crezipsa.application.community.usecase;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import org.springframework.data.domain.Page;
@@ -12,6 +10,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import tave.crezipsa.crezipsa.application.community.cache.CommunityCacheService;
+import tave.crezipsa.crezipsa.application.community.dto.cache.CommunityDetailCacheDto;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommunityCreateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommunityUpdateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.response.CommentResponse;
@@ -19,7 +19,6 @@ import tave.crezipsa.crezipsa.application.community.dto.response.CommunityDetail
 import tave.crezipsa.crezipsa.application.community.dto.response.CommunityResponse;
 import tave.crezipsa.crezipsa.application.community.dto.response.CommunitySummaryResponse;
 import tave.crezipsa.crezipsa.application.community.dto.response.MyCommunityResponse;
-import tave.crezipsa.crezipsa.application.community.dto.response.WriterResponse;
 import tave.crezipsa.crezipsa.domain.community.domain.Community;
 import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
 import tave.crezipsa.crezipsa.domain.community.domain.LikeId;
@@ -27,10 +26,11 @@ import tave.crezipsa.crezipsa.domain.community.domain.Like;
 import tave.crezipsa.crezipsa.domain.community.repository.CommentRepository;
 import tave.crezipsa.crezipsa.domain.community.repository.CommunityRepository;
 import tave.crezipsa.crezipsa.domain.community.repository.LikeRepository;
-import tave.crezipsa.crezipsa.domain.user.entity.User;
-import tave.crezipsa.crezipsa.domain.user.repository.UserRepository;
 import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
 import tave.crezipsa.crezipsa.global.exception.model.CommonException;
+
+import java.util.Collections;
+import java.util.Map;
 
 @Service
 @Transactional
@@ -41,8 +41,7 @@ public class CommunityUseCaseImpl implements CommunityUseCase {
 	private final CommunityRepository communityRepository;
 	private final LikeRepository likeRepository;
 	private final CommentRepository commentRepository;
-	private final UserRepository userRepository;
-	private final CommentUsecase commentUsecase;
+	private final CommunityCacheService communityCacheService;
 
 	@Override
 	public CommunityResponse createCommunity(Long userId, CommunityCreateRequest request) {
@@ -54,11 +53,13 @@ public class CommunityUseCaseImpl implements CommunityUseCase {
 			userId
 		);
 
-		return CommunityResponse.of(communityRepository.save(community));
+		CommunityResponse response = CommunityResponse.of(communityRepository.save(community));
+		communityCacheService.evictCommunityLists();
+		return response;
 	}
 
 	@Override
-	public CommunityResponse updateCommunity(Long communityId,Long userId, CommunityUpdateRequest communityUpdateRequest) {
+	public CommunityResponse updateCommunity(Long communityId, Long userId, CommunityUpdateRequest communityUpdateRequest) {
 		Community community = communityRepository.findById(communityId)
 			.orElseThrow(() -> new CommonException(ErrorCode.COMMUNITY_NOT_FOUND));
 
@@ -66,41 +67,32 @@ public class CommunityUseCaseImpl implements CommunityUseCase {
 			throw new CommonException(ErrorCode.UNAUTHORIZED_COMMUNITY);
 		}
 		community.update(communityUpdateRequest.getTitle(), communityUpdateRequest.getContent(), communityUpdateRequest.getImageUrls());
+		communityCacheService.evictCommunityAll(communityId);
 		return CommunityResponse.of(community);
 	}
 
 	@Override
 	@Transactional(readOnly = true)
 	public CommunityDetailResponse getCommunity(Long communityId, Long userId) {
-		Community community = communityRepository.findById(communityId)
-			.orElseThrow(() -> new CommonException(ErrorCode.COMMUNITY_NOT_FOUND));
+		CommunityDetailCacheDto cached = communityCacheService.getCommunityDetailCache(communityId);
 
-		User writerUser = userRepository.findById(community.getWriterId())
-			.orElseThrow(() -> new CommonException(ErrorCode.USER_NOT_FOUND));
-
-		long commentCount = commentRepository.countByCommunityId(communityId);
-		List<CommentResponse> comments = commentUsecase.getComments(communityId, userId);
-		WriterResponse writer = WriterResponse.from(writerUser);
-		boolean isWriter = Objects.equals(community.getWriterId(), userId);
 		boolean isLiked = likeRepository.findById(new LikeId(userId, communityId))
 			.map(Like::isLiked)
 			.orElse(false);
+		boolean isWriter = Objects.equals(cached.writerId(), userId);
 
-		return CommunityDetailResponse.from(community,writer,isWriter,isLiked, commentCount, comments);
+		List<CommentResponse> comments = cached.comments().stream()
+			.map(dto -> dto.toResponse(userId))
+			.toList();
+
+		return cached.toResponse(isWriter, isLiked, comments);
 	}
 
 	@Override
 	@Transactional(readOnly = true)
 	public List<CommunitySummaryResponse> getAllCommunities() {
-		List<Community> communities = communityRepository.findAll();
-		Map<Long, Long> commentCounts = loadCommentCounts(communities);
-
-		return communities.stream()
-			.map(c -> CommunitySummaryResponse.of(
-				c,
-				c.getLikeCount(),
-				commentCounts.getOrDefault(c.getCommunityId(), 0L)
-			))
+		return communityCacheService.getAllCommunitiesCache().stream()
+			.map(dto -> dto.toResponse())
 			.toList();
 	}
 
@@ -113,6 +105,7 @@ public class CommunityUseCaseImpl implements CommunityUseCase {
 			throw new CommonException(ErrorCode.UNAUTHORIZED_COMMUNITY);
 		}
 		communityRepository.delete(community);
+		communityCacheService.evictCommunityAndComments(communityId);
 	}
 
 	@Override
@@ -122,8 +115,8 @@ public class CommunityUseCaseImpl implements CommunityUseCase {
 
 		Page<Community> pageResult =
 			"popular".equals(sort)
-				? communityRepository.findMyCommunitiesPopular(userId,field, pageable)
-				: communityRepository.findMyCommunitiesLatest(userId,field, pageable);
+				? communityRepository.findMyCommunitiesPopular(userId, field, pageable)
+				: communityRepository.findMyCommunitiesLatest(userId, field, pageable);
 		Map<Long, Long> commentCounts = loadCommentCounts(pageResult.getContent());
 
 		return pageResult
@@ -138,15 +131,8 @@ public class CommunityUseCaseImpl implements CommunityUseCase {
 	@Override
 	@Transactional(readOnly = true)
 	public List<CommunitySummaryResponse> getCommunitiesByField(CommunityField field) {
-		List<Community> communities = communityRepository.findByField(field);
-		Map<Long, Long> commentCounts = loadCommentCounts(communities);
-
-		return communities.stream()
-			.map(c -> CommunitySummaryResponse.of(
-				c,
-				c.getLikeCount(),
-				commentCounts.getOrDefault(c.getCommunityId(), 0L)
-			))
+		return communityCacheService.getCommunitiesByFieldCache(field).stream()
+			.map(dto -> dto.toResponse())
 			.toList();
 	}
 
@@ -162,7 +148,6 @@ public class CommunityUseCaseImpl implements CommunityUseCase {
 		if (q.length() > MAX_KEYWORD_LENGTH) {
 			throw new CommonException(ErrorCode.SEARCH_KEYWORD_TOO_LONG);
 		}
-
 
 		Pageable pageable = PageRequest.of(page, size);
 
@@ -190,5 +175,4 @@ public class CommunityUseCaseImpl implements CommunityUseCase {
 			.toList();
 		return commentRepository.countByCommunityIds(communityIds);
 	}
-
 }

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/CommunityUseCaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/CommunityUseCaseImpl.java
@@ -26,6 +26,7 @@ import tave.crezipsa.crezipsa.domain.community.domain.Like;
 import tave.crezipsa.crezipsa.domain.community.repository.CommentRepository;
 import tave.crezipsa.crezipsa.domain.community.repository.CommunityRepository;
 import tave.crezipsa.crezipsa.domain.community.repository.LikeRepository;
+import tave.crezipsa.crezipsa.global.common.TransactionUtils;
 import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
 import tave.crezipsa.crezipsa.global.exception.model.CommonException;
 
@@ -54,7 +55,7 @@ public class CommunityUseCaseImpl implements CommunityUseCase {
 		);
 
 		CommunityResponse response = CommunityResponse.of(communityRepository.save(community));
-		communityCacheService.evictCommunityLists();
+		TransactionUtils.afterCommit(communityCacheService::evictCommunityLists);
 		return response;
 	}
 
@@ -67,7 +68,7 @@ public class CommunityUseCaseImpl implements CommunityUseCase {
 			throw new CommonException(ErrorCode.UNAUTHORIZED_COMMUNITY);
 		}
 		community.update(communityUpdateRequest.getTitle(), communityUpdateRequest.getContent(), communityUpdateRequest.getImageUrls());
-		communityCacheService.evictCommunityAll(communityId);
+		TransactionUtils.afterCommit(() -> communityCacheService.evictCommunityAll(communityId));
 		return CommunityResponse.of(community);
 	}
 
@@ -105,7 +106,7 @@ public class CommunityUseCaseImpl implements CommunityUseCase {
 			throw new CommonException(ErrorCode.UNAUTHORIZED_COMMUNITY);
 		}
 		communityRepository.delete(community);
-		communityCacheService.evictCommunityAndComments(communityId);
+		TransactionUtils.afterCommit(() -> communityCacheService.evictCommunityAndComments(communityId));
 	}
 
 	@Override

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImpl.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import tave.crezipsa.crezipsa.application.community.cache.CommunityCacheService;
 import tave.crezipsa.crezipsa.application.community.dto.response.MyLikedCommunityResponse;
 import tave.crezipsa.crezipsa.domain.community.domain.Community;
 import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
@@ -28,6 +29,7 @@ public class LikeUseCaseImpl  implements LikeUseCase {
 	private final LikeRepository likeRepository;
 	private final CommunityRepository communityRepository;
 	private final CommentRepository commentRepository;
+	private final CommunityCacheService communityCacheService;
 
 	@Override
 	public void like(Long userId, Long communityId) {
@@ -51,6 +53,7 @@ public class LikeUseCaseImpl  implements LikeUseCase {
 			like.like();
 			community.increaseLikeCount();
 		}
+		communityCacheService.evictCommunityAll(communityId);
 	}
 
 	@Override
@@ -68,7 +71,7 @@ public class LikeUseCaseImpl  implements LikeUseCase {
 		}
 		like.unlike();
 		community.decreaseLikeCount();
-
+		communityCacheService.evictCommunityAll(communityId);
 	}
 
 	@Override

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImpl.java
@@ -16,6 +16,7 @@ import tave.crezipsa.crezipsa.domain.community.domain.LikeId;
 import tave.crezipsa.crezipsa.domain.community.repository.CommentRepository;
 import tave.crezipsa.crezipsa.domain.community.repository.CommunityRepository;
 import tave.crezipsa.crezipsa.domain.community.repository.LikeRepository;
+import tave.crezipsa.crezipsa.global.common.TransactionUtils;
 import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
 import tave.crezipsa.crezipsa.global.exception.model.CommonException;
 
@@ -51,7 +52,7 @@ public class LikeUseCaseImpl  implements LikeUseCase {
 			like.like();
 			community.increaseLikeCount();
 		}
-		communityCacheService.evictCommunityAll(communityId);
+		TransactionUtils.afterCommit(() -> communityCacheService.evictCommunityAll(communityId));
 	}
 
 	@Override
@@ -69,7 +70,7 @@ public class LikeUseCaseImpl  implements LikeUseCase {
 		}
 		like.unlike();
 		community.decreaseLikeCount();
-		communityCacheService.evictCommunityAll(communityId);
+		TransactionUtils.afterCommit(() -> communityCacheService.evictCommunityAll(communityId));
 	}
 
 	@Override

--- a/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImpl.java
@@ -1,7 +1,5 @@
 package tave.crezipsa.crezipsa.application.community.usecase;
 
-import java.time.LocalDateTime;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -99,19 +97,4 @@ public class LikeUseCaseImpl  implements LikeUseCase {
 		});
 	}
 
-	public static String preview(String content) {
-		return content.substring(0, Math.min(50, content.length()));
-	}
-
-	public static String convertToRelativeTime(LocalDateTime createdAt) {
-		LocalDateTime now = LocalDateTime.now();
-		long minutes = java.time.Duration.between(createdAt, now).toMinutes();
-		long hours = minutes / 60;
-		long days = hours / 24;
-
-		if (minutes < 1) return "방금 전";
-		if (minutes < 60) return minutes + "분 전";
-		if (hours < 24) return hours + "시간 전";
-		return days + "일 전";
-	}
 }

--- a/src/main/java/tave/crezipsa/crezipsa/global/common/TimeUtils.java
+++ b/src/main/java/tave/crezipsa/crezipsa/global/common/TimeUtils.java
@@ -1,0 +1,24 @@
+package tave.crezipsa.crezipsa.global.common;
+
+import java.time.LocalDateTime;
+
+public final class TimeUtils {
+
+	private TimeUtils() {}
+
+	public static String convertToRelativeTime(LocalDateTime createdAt) {
+		LocalDateTime now = LocalDateTime.now();
+		long minutes = java.time.Duration.between(createdAt, now).toMinutes();
+		long hours = minutes / 60;
+		long days = hours / 24;
+
+		if (minutes < 1) return "방금 전";
+		if (minutes < 60) return minutes + "분 전";
+		if (hours < 24) return hours + "시간 전";
+		return days + "일 전";
+	}
+
+	public static String preview(String content) {
+		return content.substring(0, Math.min(50, content.length()));
+	}
+}

--- a/src/main/java/tave/crezipsa/crezipsa/global/common/TransactionUtils.java
+++ b/src/main/java/tave/crezipsa/crezipsa/global/common/TransactionUtils.java
@@ -1,0 +1,27 @@
+package tave.crezipsa.crezipsa.global.common;
+
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public final class TransactionUtils {
+
+	private TransactionUtils() {}
+
+	/**
+	 * 활성 트랜잭션이 있으면 커밋 후에, 없으면 즉시 실행한다.
+	 * 캐시 퇴거를 트랜잭션 커밋 이전에 수행하면 다른 요청이 커밋 전 스냅샷을
+	 * 캐시에 채워넣는 레이스 컨디션이 발생하므로 이 메서드로 연기한다.
+	 */
+	public static void afterCommit(Runnable action) {
+		if (TransactionSynchronizationManager.isActualTransactionActive()) {
+			TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+				@Override
+				public void afterCommit() {
+					action.run();
+				}
+			});
+		} else {
+			action.run();
+		}
+	}
+}

--- a/src/main/java/tave/crezipsa/crezipsa/global/config/CacheConfig.java
+++ b/src/main/java/tave/crezipsa/crezipsa/global/config/CacheConfig.java
@@ -4,7 +4,6 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,7 +14,6 @@ import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSeriali
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -25,14 +23,12 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 public class CacheConfig {
 
 	@Bean
-	@ConditionalOnBean(RedisConnectionFactory.class)
 	public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
 		ObjectMapper objectMapper = new ObjectMapper()
 			.registerModule(new JavaTimeModule())
 			.activateDefaultTyping(
 				LaissezFaireSubTypeValidator.instance,
-				ObjectMapper.DefaultTyping.NON_FINAL,
-				JsonTypeInfo.As.PROPERTY
+				ObjectMapper.DefaultTyping.NON_FINAL
 			);
 
 		GenericJackson2JsonRedisSerializer jsonSerializer =

--- a/src/main/java/tave/crezipsa/crezipsa/global/config/CacheConfig.java
+++ b/src/main/java/tave/crezipsa/crezipsa/global/config/CacheConfig.java
@@ -1,0 +1,60 @@
+package tave.crezipsa.crezipsa.global.config;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+	@Bean
+	@ConditionalOnBean(RedisConnectionFactory.class)
+	public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+		ObjectMapper objectMapper = new ObjectMapper()
+			.registerModule(new JavaTimeModule())
+			.activateDefaultTyping(
+				LaissezFaireSubTypeValidator.instance,
+				ObjectMapper.DefaultTyping.NON_FINAL,
+				JsonTypeInfo.As.PROPERTY
+			);
+
+		GenericJackson2JsonRedisSerializer jsonSerializer =
+			new GenericJackson2JsonRedisSerializer(objectMapper);
+
+		RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+			.entryTtl(Duration.ofMinutes(5))
+			.serializeKeysWith(
+				RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+			.serializeValuesWith(
+				RedisSerializationContext.SerializationPair.fromSerializer(jsonSerializer))
+			.disableCachingNullValues();
+
+		Map<String, RedisCacheConfiguration> cacheConfigs = new HashMap<>();
+		cacheConfigs.put("community-list", defaultConfig);
+		cacheConfigs.put("community-list-by-field", defaultConfig);
+		cacheConfigs.put("community-detail", defaultConfig);
+		cacheConfigs.put("comment-list", defaultConfig);
+
+		return RedisCacheManager.builder(connectionFactory)
+			.cacheDefaults(defaultConfig)
+			.withInitialCacheConfigurations(cacheConfigs)
+			.build();
+	}
+}

--- a/src/test/java/tave/crezipsa/crezipsa/application/community/usecase/CommentUseCaseImplTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/application/community/usecase/CommentUseCaseImplTest.java
@@ -7,10 +7,10 @@ import static tave.crezipsa.crezipsa.fixture.CommentFixture.*;
 import static tave.crezipsa.crezipsa.fixture.CommunityFixture.*;
 import static tave.crezipsa.crezipsa.fixture.UserFixture.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -18,17 +18,18 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
+import tave.crezipsa.crezipsa.application.community.cache.CommunityCacheService;
+import tave.crezipsa.crezipsa.application.community.dto.cache.CommentCacheDto;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommentCreateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommentUpdateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.response.CommentResponse;
 import tave.crezipsa.crezipsa.application.community.dto.response.MyCommentResponse;
 import tave.crezipsa.crezipsa.application.community.dto.response.WriterResponse;
 import tave.crezipsa.crezipsa.application.community.mapper.CommentMapper;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-
 import tave.crezipsa.crezipsa.domain.community.domain.Comment;
 import tave.crezipsa.crezipsa.domain.community.domain.Community;
 import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
@@ -50,6 +51,8 @@ class CommentUseCaseImplTest {
 	private UserRepository userRepository;
 	@Mock
 	private CommentMapper commentMapper;
+	@Mock
+	private CommunityCacheService communityCacheService;
 
 	@InjectMocks
 	private CommentUseCaseImpl sut;
@@ -83,6 +86,7 @@ class CommentUseCaseImplTest {
 			assertThat(result.commentId()).isEqualTo(100L);
 			assertThat(result.parentId()).isNull();
 			verify(commentRepository).save(any(Comment.class));
+			verify(communityCacheService).evictCommentsAndDetail(communityId);
 		}
 
 		@Test
@@ -205,6 +209,7 @@ class CommentUseCaseImplTest {
 			assertThat(rootComment.isDeleted()).isTrue();
 			assertThat(rootComment.getContent()).isEqualTo("삭제된 메시지입니다");
 			verify(commentRepository, never()).delete(any());
+			verify(communityCacheService).evictCommentsAndDetail(1L);
 		}
 
 		@Test
@@ -220,6 +225,7 @@ class CommentUseCaseImplTest {
 			// then
 			assertThat(childComment.isDeleted()).isFalse();
 			verify(commentRepository).delete(childComment);
+			verify(communityCacheService).evictCommentsAndDetail(1L);
 		}
 
 		@Test
@@ -298,6 +304,7 @@ class CommentUseCaseImplTest {
 
 			// then
 			assertThat(result.content()).isEqualTo("updated");
+			verify(communityCacheService).evictCommentsAndDetail(1L);
 		}
 	}
 
@@ -319,38 +326,32 @@ class CommentUseCaseImplTest {
 		}
 
 		@Test
-		@DisplayName("루트 댓글과 자식 댓글을 트리 구조로 조합")
+		@DisplayName("루트 댓글과 자식 댓글을 트리 구조로 반환")
 		void buildsNestedTree() {
 			// given
 			Long communityId = 1L;
 			Long viewerId = 50L;
 			Community community = createCommunity(communityId);
 
-			Comment root1 = createComment(1L, communityId, 10L, null);
-			Comment child1 = createComment(2L, communityId, 20L, 1L);
-			Comment root2 = createComment(3L, communityId, 30L, null);
-
 			User user10 = createUser(10L);
 			User user20 = createUser(20L);
 			User user30 = createUser(30L);
 
-			when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
-			when(commentRepository.findByCommunityId(communityId)).thenReturn(List.of(root1, child1, root2));
-			when(userRepository.findAllById(any())).thenReturn(List.of(user10, user20, user30));
+			CommentCacheDto child1 = new CommentCacheDto(
+				2L, communityId, 1L, 20L, WriterResponse.from(user20),
+				false, "child comment", LocalDateTime.now(), List.of()
+			);
+			CommentCacheDto root1 = new CommentCacheDto(
+				1L, communityId, null, 10L, WriterResponse.from(user10),
+				false, "root comment 1", LocalDateTime.now(), List.of(child1)
+			);
+			CommentCacheDto root2 = new CommentCacheDto(
+				3L, communityId, null, 30L, WriterResponse.from(user30),
+				false, "root comment 2", LocalDateTime.now(), List.of()
+			);
 
-			when(commentMapper.toCommentResponse(any(), any(), anyBoolean(), anyString(), anyList()))
-				.thenAnswer(invocation -> {
-					Comment c = invocation.getArgument(0);
-					User w = invocation.getArgument(1);
-					boolean isW = invocation.getArgument(2);
-					String rt = invocation.getArgument(3);
-					List<CommentResponse> replies = invocation.getArgument(4);
-					return new CommentResponse(
-						c.getCommentId(), c.getCommunityId(), c.getParentId(),
-						WriterResponse.from(w), isW, c.isDeleted(), c.getContent(),
-						c.getCreatedAt(), rt, replies
-					);
-				});
+			when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
+			when(communityCacheService.getCommentsCache(communityId)).thenReturn(List.of(root1, root2));
 
 			// when
 			List<CommentResponse> result = sut.getComments(communityId, viewerId);
@@ -369,40 +370,20 @@ class CommentUseCaseImplTest {
 		}
 
 		@Test
-		@DisplayName("빈 댓글 목록이면 빈 리스트 반환하고 User 조회 안 함")
-		void emptyComments_returnsEmptyAndSkipsUserLookup() {
+		@DisplayName("빈 댓글 목록이면 빈 리스트 반환")
+		void emptyComments_returnsEmpty() {
 			// given
 			Long communityId = 1L;
 			Community community = createCommunity(communityId);
 
 			when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
-			when(commentRepository.findByCommunityId(communityId)).thenReturn(List.of());
+			when(communityCacheService.getCommentsCache(communityId)).thenReturn(List.of());
 
 			// when
 			List<CommentResponse> result = sut.getComments(communityId, 1L);
 
 			// then
 			assertThat(result).isEmpty();
-			verify(userRepository, never()).findAllById(any());
-		}
-
-		@Test
-		@DisplayName("댓글 작성자의 writerMap에 없는 userId가 있으면 USER_NOT_FOUND 예외")
-		void writerNotInMap_throwsUserNotFound() {
-			// given
-			Long communityId = 1L;
-			Community community = createCommunity(communityId);
-			Comment comment = createComment(1L, communityId, 999L, null);
-
-			when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
-			when(commentRepository.findByCommunityId(communityId)).thenReturn(List.of(comment));
-			when(userRepository.findAllById(any())).thenReturn(List.of());
-
-			// when & then
-			assertThatThrownBy(() -> sut.getComments(communityId, 1L))
-				.isInstanceOf(CommonException.class)
-				.extracting("errorCode")
-				.isEqualTo(ErrorCode.USER_NOT_FOUND);
 		}
 	}
 

--- a/src/test/java/tave/crezipsa/crezipsa/application/community/usecase/CommunityUseCaseImplTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/application/community/usecase/CommunityUseCaseImplTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 import static tave.crezipsa.crezipsa.fixture.CommunityFixture.*;
 import static tave.crezipsa.crezipsa.fixture.UserFixture.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -22,12 +23,16 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import tave.crezipsa.crezipsa.application.community.cache.CommunityCacheService;
+import tave.crezipsa.crezipsa.application.community.dto.cache.CommunityDetailCacheDto;
+import tave.crezipsa.crezipsa.application.community.dto.cache.CommunitySummaryCacheDto;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommunityCreateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.request.CommunityUpdateRequest;
 import tave.crezipsa.crezipsa.application.community.dto.response.CommunityDetailResponse;
 import tave.crezipsa.crezipsa.application.community.dto.response.CommunityResponse;
 import tave.crezipsa.crezipsa.application.community.dto.response.CommunitySummaryResponse;
 import tave.crezipsa.crezipsa.application.community.dto.response.MyCommunityResponse;
+import tave.crezipsa.crezipsa.application.community.dto.response.WriterResponse;
 import tave.crezipsa.crezipsa.domain.community.domain.Community;
 import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
 import tave.crezipsa.crezipsa.domain.community.domain.Like;
@@ -36,7 +41,6 @@ import tave.crezipsa.crezipsa.domain.community.repository.CommentRepository;
 import tave.crezipsa.crezipsa.domain.community.repository.CommunityRepository;
 import tave.crezipsa.crezipsa.domain.community.repository.LikeRepository;
 import tave.crezipsa.crezipsa.domain.user.entity.User;
-import tave.crezipsa.crezipsa.domain.user.repository.UserRepository;
 import tave.crezipsa.crezipsa.global.exception.code.ErrorCode;
 import tave.crezipsa.crezipsa.global.exception.model.CommonException;
 
@@ -50,9 +54,7 @@ class CommunityUseCaseImplTest {
 	@Mock
 	private CommentRepository commentRepository;
 	@Mock
-	private UserRepository userRepository;
-	@Mock
-	private CommentUsecase commentUsecase;
+	private CommunityCacheService communityCacheService;
 
 	@InjectMocks
 	private CommunityUseCaseImpl sut;
@@ -85,6 +87,7 @@ class CommunityUseCaseImplTest {
 			assertThat(result.title()).isEqualTo("제목");
 			assertThat(result.field()).isEqualTo(CommunityField.RECOMMEND);
 			verify(communityRepository).save(any(Community.class));
+			verify(communityCacheService).evictCommunityLists();
 		}
 	}
 
@@ -135,6 +138,7 @@ class CommunityUseCaseImplTest {
 			// then
 			assertThat(result.title()).isEqualTo("updated title");
 			assertThat(result.content()).isEqualTo("테스트 내용입니다. 충분히 긴 내용으로 preview 테스트도 가능합니다.");
+			verify(communityCacheService).evictCommunityAll(1L);
 		}
 	}
 
@@ -181,6 +185,7 @@ class CommunityUseCaseImplTest {
 
 			// then
 			verify(communityRepository).delete(community);
+			verify(communityCacheService).evictCommunityAndComments(1L);
 		}
 	}
 
@@ -196,14 +201,15 @@ class CommunityUseCaseImplTest {
 			Long writerId = 10L;
 			Long viewerId = 20L;
 
-			Community community = createCommunity(communityId, writerId);
 			User writer = createUser(writerId);
+			WriterResponse writerResponse = WriterResponse.from(writer);
+			CommunityDetailCacheDto cached = new CommunityDetailCacheDto(
+				communityId, writerId, "테스트 제목", "테스트 내용", CommunityField.RECOMMEND,
+				List.of("img1.jpg"), writerResponse, 0L, 5L, LocalDateTime.now(), List.of()
+			);
 			Like like = Like.of(viewerId, communityId);
 
-			when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
-			when(userRepository.findById(writerId)).thenReturn(Optional.of(writer));
-			when(commentRepository.countByCommunityId(communityId)).thenReturn(5L);
-			when(commentUsecase.getComments(communityId, viewerId)).thenReturn(List.of());
+			when(communityCacheService.getCommunityDetailCache(communityId)).thenReturn(cached);
 			when(likeRepository.findById(new LikeId(viewerId, communityId))).thenReturn(Optional.of(like));
 
 			// when
@@ -221,7 +227,8 @@ class CommunityUseCaseImplTest {
 		@DisplayName("존재하지 않는 게시글이면 COMMUNITY_NOT_FOUND 예외")
 		void communityNotFound_throws() {
 			// given
-			when(communityRepository.findById(999L)).thenReturn(Optional.empty());
+			when(communityCacheService.getCommunityDetailCache(999L))
+				.thenThrow(new CommonException(ErrorCode.COMMUNITY_NOT_FOUND));
 
 			// when & then
 			assertThatThrownBy(() -> sut.getCommunity(999L, 1L))
@@ -235,10 +242,8 @@ class CommunityUseCaseImplTest {
 		void writerNotFound_throws() {
 			// given
 			Long communityId = 1L;
-			Community community = createCommunity(communityId, 999L);
-
-			when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
-			when(userRepository.findById(999L)).thenReturn(Optional.empty());
+			when(communityCacheService.getCommunityDetailCache(communityId))
+				.thenThrow(new CommonException(ErrorCode.USER_NOT_FOUND));
 
 			// when & then
 			assertThatThrownBy(() -> sut.getCommunity(communityId, 1L))
@@ -254,13 +259,14 @@ class CommunityUseCaseImplTest {
 			Long communityId = 1L;
 			Long writerId = 10L;
 
-			Community community = createCommunity(communityId, writerId);
 			User writer = createUser(writerId);
+			WriterResponse writerResponse = WriterResponse.from(writer);
+			CommunityDetailCacheDto cached = new CommunityDetailCacheDto(
+				communityId, writerId, "테스트 제목", "테스트 내용", CommunityField.RECOMMEND,
+				List.of(), writerResponse, 0L, 0L, LocalDateTime.now(), List.of()
+			);
 
-			when(communityRepository.findById(communityId)).thenReturn(Optional.of(community));
-			when(userRepository.findById(writerId)).thenReturn(Optional.of(writer));
-			when(commentRepository.countByCommunityId(communityId)).thenReturn(0L);
-			when(commentUsecase.getComments(communityId, writerId)).thenReturn(List.of());
+			when(communityCacheService.getCommunityDetailCache(communityId)).thenReturn(cached);
 			when(likeRepository.findById(any(LikeId.class))).thenReturn(Optional.empty());
 
 			// when
@@ -322,12 +328,14 @@ class CommunityUseCaseImplTest {
 	class GetCommunitiesByField {
 
 		@Test
-		@DisplayName("필드별 커뮤니티 조회 시 댓글 수 포함하여 반환")
+		@DisplayName("필드별 커뮤니티 조회 시 캐시 서비스에 위임하여 반환")
 		void returnsByFieldWithCommentCounts() {
 			// given
-			Community c1 = createCommunity(1L, 10L);
-			when(communityRepository.findByField(CommunityField.RECOMMEND)).thenReturn(List.of(c1));
-			when(commentRepository.countByCommunityIds(List.of(1L))).thenReturn(Map.of(1L, 2L));
+			CommunitySummaryCacheDto dto = new CommunitySummaryCacheDto(
+				1L, CommunityField.RECOMMEND, "테스트 제목", "테스트 내용...", 0L, 2L, LocalDateTime.now(), null
+			);
+			when(communityCacheService.getCommunitiesByFieldCache(CommunityField.RECOMMEND))
+				.thenReturn(List.of(dto));
 
 			// when
 			List<CommunitySummaryResponse> result = sut.getCommunitiesByField(CommunityField.RECOMMEND);
@@ -419,15 +427,16 @@ class CommunityUseCaseImplTest {
 	class GetAllCommunities {
 
 		@Test
-		@DisplayName("댓글 수를 배치로 로드하여 N+1 방지")
-		void batchLoadsCommentCounts() {
+		@DisplayName("캐시 서비스에 위임하고 댓글 수 포함하여 반환")
+		void delegatesToCacheService() {
 			// given
-			Community c1 = createCommunity(1L, 10L);
-			Community c2 = createCommunity(2L, 10L);
-
-			when(communityRepository.findAll()).thenReturn(List.of(c1, c2));
-			when(commentRepository.countByCommunityIds(List.of(1L, 2L)))
-				.thenReturn(Map.of(1L, 3L, 2L, 7L));
+			CommunitySummaryCacheDto dto1 = new CommunitySummaryCacheDto(
+				1L, CommunityField.RECOMMEND, "제목1", "내용1...", 0L, 3L, LocalDateTime.now(), null
+			);
+			CommunitySummaryCacheDto dto2 = new CommunitySummaryCacheDto(
+				2L, CommunityField.TIP, "제목2", "내용2...", 0L, 7L, LocalDateTime.now(), null
+			);
+			when(communityCacheService.getAllCommunitiesCache()).thenReturn(List.of(dto1, dto2));
 
 			// when
 			List<CommunitySummaryResponse> result = sut.getAllCommunities();
@@ -436,21 +445,20 @@ class CommunityUseCaseImplTest {
 			assertThat(result).hasSize(2);
 			assertThat(result.get(0).commentCount()).isEqualTo(3L);
 			assertThat(result.get(1).commentCount()).isEqualTo(7L);
-			verify(commentRepository, times(1)).countByCommunityIds(anyList());
+			verify(communityCacheService).getAllCommunitiesCache();
 		}
 
 		@Test
-		@DisplayName("빈 목록이면 배치 호출하지 않음")
-		void emptyList_noBatchCall() {
+		@DisplayName("빈 목록이면 빈 리스트 반환")
+		void emptyList_returnsEmpty() {
 			// given
-			when(communityRepository.findAll()).thenReturn(List.of());
+			when(communityCacheService.getAllCommunitiesCache()).thenReturn(List.of());
 
 			// when
 			List<CommunitySummaryResponse> result = sut.getAllCommunities();
 
 			// then
 			assertThat(result).isEmpty();
-			verify(commentRepository, never()).countByCommunityIds(anyList());
 		}
 	}
 }

--- a/src/test/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImplTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImplTest.java
@@ -21,6 +21,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 
+import tave.crezipsa.crezipsa.application.community.cache.CommunityCacheService;
 import tave.crezipsa.crezipsa.application.community.dto.response.MyLikedCommunityResponse;
 import tave.crezipsa.crezipsa.domain.community.domain.Community;
 import tave.crezipsa.crezipsa.domain.community.domain.CommunityField;
@@ -41,6 +42,8 @@ class LikeUseCaseImplTest {
 	private CommunityRepository communityRepository;
 	@Mock
 	private CommentRepository commentRepository;
+	@Mock
+	private CommunityCacheService communityCacheService;
 
 	@InjectMocks
 	private LikeUseCaseImpl sut;
@@ -89,6 +92,7 @@ class LikeUseCaseImplTest {
 			assertThat(existingLike.isLiked()).isFalse();
 			assertThat(community.getLikeCount()).isZero();
 			verify(likeRepository, never()).save(any());
+			verify(communityCacheService).evictCommunityAll(communityId);
 		}
 
 		@Test
@@ -111,6 +115,7 @@ class LikeUseCaseImplTest {
 			// then
 			assertThat(existingLike.isLiked()).isTrue();
 			assertThat(community.getLikeCount()).isEqualTo(1L);
+			verify(communityCacheService).evictCommunityAll(communityId);
 		}
 
 		@Test
@@ -203,6 +208,7 @@ class LikeUseCaseImplTest {
 			// then
 			assertThat(existingLike.isLiked()).isFalse();
 			assertThat(community.getLikeCount()).isZero();
+			verify(communityCacheService).evictCommunityAll(communityId);
 		}
 	}
 


### PR DESCRIPTION
## 개요

커뮤니티 목록·상세·댓글 조회 API가 매 요청마다 DB를 다중 조회하는 구조였습니다.
이미 인프라에 올라와 있는 Redis를 활용해 Spring Cache 추상화를 적용하고, 부하 테스트로 성능 개선을 수치로 검증했습니다.

---

## 구현 내용

### 1. CacheConfig
`RedisCacheManager` 빈을 등록하고 Jackson 직렬화(GenericJackson2JsonRedisSerializer)와 TTL 5분을 설정합니다.
캐시 키 전략상 userId를 포함하지 않아 사용자 수에 무관하게 캐시 엔트리가 일정하게 유지됩니다.

> **직렬화 이슈 해결**
> Java `record`는 `final` 클래스라 `DefaultTyping.NON_FINAL` 설정에서 타입 정보가 직렬화되지 않아
> 역직렬화 시 `MismatchedInputException`이 발생했습니다.
> CacheDto 3종에 `@JsonTypeInfo(use = CLASS, include = WRAPPER_ARRAY)`를 명시해 해결했습니다.

### 2. CommunityCacheService (별도 빈 분리)
`@Cacheable` / `@CacheEvict`를 한 곳에서 관리합니다.
같은 클래스 내부에서 호출하면 AOP 프록시가 동작하지 않는 **self-invocation 문제**를 피하기 위해 별도 빈으로 분리했습니다.

| 메서드 | 캐시 이름 | KEY |
|--------|-----------|-----|
| `getAllCommunitiesCache()` | `community-list` | `"all"` |
| `getCommunitiesByFieldCache(field)` | `community-list-by-field` | `field.name()` |
| `getCommunityDetailCache(communityId)` | `community-detail` | `communityId` |
| `getCommentsCache(communityId)` | `comment-list` | `communityId` |

### 3. CacheDto 3종
`relativeTime`("40분 전" 등)은 캐시에 저장하면 시간이 고정되므로 raw `LocalDateTime`으로 저장하고,
응답 변환 시점에 재계산합니다.
`isLiked` / `isWriter`는 사용자마다 다르므로 캐시에는 저장하지 않고 캐시 조회 후 별도 계산합니다.

### 4. 캐시 무효화 전략

| 트리거 | 무효화 대상 |
|--------|------------|
| 글 작성 | `community-list`, `community-list-by-field` |
| 글 수정 | 위 2개 + `community-detail::{id}` |
| 글 삭제 | 위 3개 + `comment-list::{id}` |
| 댓글 생성/수정/삭제 | `community-detail::{communityId}`, `comment-list::{communityId}` |
| 좋아요/취소 | `community-detail::{communityId}`, 목록 캐시 전체 |

---

## 부하 테스트 결과

### 배경 — JMeter 설정 실수와 수정

**첫 번째 JMeter 실행 (잘못된 설정)**

```
Threads: 100 / Ramp-Up: 130초 / Loop Count: 10 / Duration: 120초
```

`Ramp-Up(130초) > Duration(120초)` 로 설정되어 있어, **테스트가 끝날 때까지 100개 스레드가 다 뜨지 않습니다.**
루프 횟수도 10회로 제한되어 실제 동시 사용자는 약 46명 수준, 처리량은 30 req/s에 불과했습니다.
이 조건에서는 DB에 가해지는 압박이 작아 캐싱 효과가 희석돼 평균 응답시간 개선이 23% 수준에 그쳤습니다.
-캐싱 적용 전
<img width="843" height="655" alt="스크린샷 2026-02-26 오후 4 46 38" src="https://github.com/user-attachments/assets/fa1523fc-9c89-47da-999e-330959e480c6" />

-캐싱 적용 후
<img width="836" height="496" alt="스크린샷 2026-02-26 오후 5 12 09" src="https://github.com/user-attachments/assets/f3ad832b-3d2c-4f34-93d0-dfce0b7a36ac" />



**두 번째 JMeter 실행 (수정된 설정)**

```
Threads: 100 / Ramp-Up: 30초 / Loop Count: Infinite / Duration: 120초
```

Ramp-Up을 Duration 이하로 줄이고 Loop를 무한으로 설정해 **실제 100 VU가 120초 동안 지속적으로 부하를 줍니다.**

| 지표 | 캐싱 전 | 캐싱 후 | 개선율 |
|------|:-------:|:-------:|:------:|
| Average | 130ms | 103ms | **-20.8%** |
| p90 | 220ms | 172ms | **-21.8%** |
| p95 | 260ms | 204ms | **-21.5%** |
| p99 | 358ms | 286ms | **-20.1%** |
| Max | 796ms | 726ms | -8.8% |
| Throughput | 668/s | 839/s | **+25.5%** |
| Std Dev | 73.8 | 58.8 | **-20.3%** |

API별 평균 응답시간 (캐싱 전 → 후)

| API | 전 | 후 | 개선율 |
|-----|:--:|:--:|:------:|
| getAllCommunities | 128ms | 102ms | -20.3% |
| getByField | 128ms | 101ms | -21.1% |
| getCommunityDetail | 135ms | 106ms | -21.5% |
| getComments | 127ms | 104ms | -18.1% |

-캐싱 전
<img width="831" height="474" alt="스크린샷 2026-02-26 오후 6 14 37" src="https://github.com/user-attachments/assets/181d9209-0053-4d46-a4e3-815101865cd4" />

-캐싱 후
<img width="837" height="472" alt="스크린샷 2026-02-26 오후 6 18 40" src="https://github.com/user-attachments/assets/e5601476-b84a-4a40-b4da-1bdbdb7153d6" />

---

### k6 병행 검증

JMeter와 독립적으로 k6를 이용해 같은 시나리오를 검증했습니다.

**k6 설정 설명**

```js
stages: [
  { duration: '10s', target: 50 },   // 예열: 10초에 걸쳐 VU를 0→50명으로 증가
  { duration: '30s', target: 100 },  // 본 측정: 30초에 걸쳐 100명까지 증가 후 유지
  { duration: '10s', target: 0 },    // 종료: 10초에 걸쳐 VU를 0으로 감소
]
```

- **VU(Virtual User)**: 동시에 요청을 보내는 가상 사용자 수입니다. JMeter의 Thread 수와 동일한 개념입니다.
- **Stages**: 부하를 단계적으로 올려 서버가 갑작스러운 트래픽 충격 없이 스케일업 과정을 거치게 합니다. Ramp-Up을 Duration 안에 포함시키는 구조라 JMeter의 설정 실수가 발생하지 않습니다.
- **각 VU의 동작**: 전체 목록 → 필드별 목록 → 상세 조회 → 댓글 조회 순서로 4개 API를 반복하며, 요청 사이에 0.1초씩 대기합니다. 실제 사용자가 페이지를 탐색하는 패턴을 모방합니다.

**k6 결과**

| 지표 | 캐싱 전 (develop) | 캐싱 후 | 개선율 |
|------|:-----------------:|:-------:|:------:|
| Average | 32.2ms | 18.5ms | **-43%** |
| p95 | 120.7ms | 53.0ms | **-56%** |
| Throughput | 379 req/s | 413 req/s | **+9%** |
| 에러율 | 0% | 0% | - |

k6는 JMeter보다 더 높은 실효 부하(~413 req/s)를 주었기 때문에 DB 커넥션 경쟁이 심해져 캐싱 효과가 더 크게 나타났습니다.

---

## 결론 — 캐싱 적용 효과가 있는가?

**있습니다.**

두 도구 모두에서 일관되게 개선이 확인됐습니다.

- **평균 응답시간**: JMeter 21% / k6 43% 감소
- **p95 응답시간**: JMeter 22% / k6 56% 감소 — 트래픽이 몰릴수록 꼬리 지연 개선 효과가 더 큽니다
- **처리량**: JMeter 25% / k6 9% 증가
- **안정성(Std Dev)**: 20% 감소 — 응답시간 편차가 줄어 서비스 일관성이 향상됐습니다

현재 로컬 환경(DB가 같은 머신)에서 측정한 수치입니다. 실제 EC2 환경에서는 RDS 네트워크 왕복 레이턴시(~2–5ms × 쿼리 수)가 추가로 붙기 때문에 **개선 폭이 더 크게 나타날 것으로 예상됩니다.**

> **Max 스파이크 잔존**: JMeter 기준 Max 796ms → 726ms로 8.8% 감소에 그쳤습니다.
> 서버 최초 기동 시 캐시가 비어 있어 첫 요청이 DB 조회 + Redis 직렬화 비용을 모두 부담하기 때문입니다.
> 운영 환경에서는 `ApplicationRunner`를 통한 Cache Warm-up으로 제거 가능합니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced caching for community data (lists, details, and comments) with Redis-backed storage and 5-minute cache expiration.
  * Added load and debug testing scripts for performance validation.

* **Chores**
  * Added Spring Cache dependency to support caching abstractions.

* **Tests**
  * Updated test suites to reflect cache-driven data retrieval patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->