### PR TITLE
[Refactor]#65 getMyLikedCommunities N+1 쿼리 제거 

### DIFF
--- a/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImpl.java
+++ b/src/main/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImpl.java
@@ -1,5 +1,8 @@
 package tave.crezipsa.crezipsa.application.community.usecase;
 
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -83,9 +86,12 @@ public class LikeUseCaseImpl  implements LikeUseCase {
 				? likeRepository.findMyLikedCommunitiesPopular(userId, field, pageable)
 				: likeRepository.findMyLikedCommunitiesLatest(userId, field, pageable);
 
+		List<Long> communityIds = page.getContent().stream()
+			.map(Community::getCommunityId).toList();
+		Map<Long, Long> commentCounts = commentRepository.countByCommunityIds(communityIds);
+
 		return page.map(community -> {
-			long commentCount =
-				commentRepository.countByCommunityId(community.getCommunityId());
+			long commentCount = commentCounts.getOrDefault(community.getCommunityId(), 0L);
 
 			return MyLikedCommunityResponse.of(
 				community,

--- a/src/test/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImplTest.java
+++ b/src/test/java/tave/crezipsa/crezipsa/application/community/usecase/LikeUseCaseImplTest.java
@@ -16,6 +16,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
+import java.util.Map;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -235,42 +238,87 @@ class LikeUseCaseImplTest {
 	class GetMyLikedCommunities {
 
 		@Test
-		@DisplayName("latest 정렬 시 findMyLikedCommunitiesLatest 호출")
-		void latestSort() {
-			// given
+		@DisplayName("latest 정렬 시 countByCommunityIds(배치)가 호출되고 commentCount가 매핑된다")
+		void latestSort_usesBatchCommentCount() {
+			// Given
 			Community c1 = createCommunity(1L, 5L);
 			Page<Community> page = new PageImpl<>(List.of(c1), PageRequest.of(0, 10), 1);
 
 			when(likeRepository.findMyLikedCommunitiesLatest(eq(10L), isNull(), any()))
 				.thenReturn(page);
-			when(commentRepository.countByCommunityId(1L)).thenReturn(3L);
+			when(commentRepository.countByCommunityIds(List.of(1L)))
+				.thenReturn(Map.of(1L, 3L));
 
-			// when
+			// When
 			Slice<MyLikedCommunityResponse> result = sut.getMyLikedCommunities(10L, null, "latest", PageRequest.of(0, 10));
 
-			// then
+			// Then
 			assertThat(result.getContent()).hasSize(1);
 			assertThat(result.getContent().get(0).commentCount()).isEqualTo(3L);
-			verify(likeRepository).findMyLikedCommunitiesLatest(eq(10L), isNull(), any());
+			verify(commentRepository).countByCommunityIds(List.of(1L));
+			verify(commentRepository, never()).countByCommunityId(anyLong());
 		}
 
 		@Test
-		@DisplayName("popular 정렬 시 findMyLikedCommunitiesPopular 호출")
-		void popularSort() {
-			// given
+		@DisplayName("popular 정렬 시 countByCommunityIds(배치)가 호출되고 단건 메서드는 호출되지 않는다")
+		void popularSort_usesBatchCommentCount() {
+			// Given
 			Community c1 = createCommunity(1L, 5L);
 			Page<Community> page = new PageImpl<>(List.of(c1), PageRequest.of(0, 10), 1);
 
 			when(likeRepository.findMyLikedCommunitiesPopular(eq(10L), eq(CommunityField.TIP), any()))
 				.thenReturn(page);
-			when(commentRepository.countByCommunityId(1L)).thenReturn(0L);
+			when(commentRepository.countByCommunityIds(List.of(1L)))
+				.thenReturn(Map.of(1L, 0L));
 
-			// when
+			// When
 			Slice<MyLikedCommunityResponse> result = sut.getMyLikedCommunities(10L, CommunityField.TIP, "popular", PageRequest.of(0, 10));
 
-			// then
+			// Then
 			assertThat(result.getContent()).hasSize(1);
 			verify(likeRepository).findMyLikedCommunitiesPopular(eq(10L), eq(CommunityField.TIP), any());
+			verify(commentRepository).countByCommunityIds(List.of(1L));
+			verify(commentRepository, never()).countByCommunityId(anyLong());
+		}
+
+		@Test
+		@DisplayName("커뮤니티가 없을 때 countByCommunityIds가 빈 리스트로 호출된다")
+		void emptyPage_callsBatchWithEmptyList() {
+			// Given
+			Page<Community> emptyPage = new PageImpl<>(Collections.emptyList(), PageRequest.of(0, 10), 0);
+
+			when(likeRepository.findMyLikedCommunitiesLatest(eq(10L), isNull(), any()))
+				.thenReturn(emptyPage);
+			when(commentRepository.countByCommunityIds(Collections.emptyList()))
+				.thenReturn(Collections.emptyMap());
+
+			// When
+			Slice<MyLikedCommunityResponse> result = sut.getMyLikedCommunities(10L, null, "latest", PageRequest.of(0, 10));
+
+			// Then
+			assertThat(result.getContent()).isEmpty();
+			verify(commentRepository).countByCommunityIds(Collections.emptyList());
+			verify(commentRepository, never()).countByCommunityId(anyLong());
+		}
+
+		@Test
+		@DisplayName("Map에 communityId가 없으면 commentCount가 0으로 기본값 처리된다")
+		void missingCommentCountEntry_defaultsToZero() {
+			// Given
+			Community c1 = createCommunity(1L, 5L);
+			Page<Community> page = new PageImpl<>(List.of(c1), PageRequest.of(0, 10), 1);
+
+			when(likeRepository.findMyLikedCommunitiesLatest(eq(10L), isNull(), any()))
+				.thenReturn(page);
+			when(commentRepository.countByCommunityIds(List.of(1L)))
+				.thenReturn(Collections.emptyMap());
+
+			// When
+			Slice<MyLikedCommunityResponse> result = sut.getMyLikedCommunities(10L, null, "latest", PageRequest.of(0, 10));
+
+			// Then
+			assertThat(result.getContent()).hasSize(1);
+			assertThat(result.getContent().get(0).commentCount()).isZero();
 		}
 	}
 }


### PR DESCRIPTION
## 문제

`LikeUseCaseImpl.getMyLikedCommunities`에서 페이지 내 커뮤니티 수만큼 DB 쿼리가 추가로 발생하는 N+1 문제가 있었습니다.

`page.map()` 람다 내부에서 `commentRepository.countByCommunityId()`를 단건으로 반복 호출하기 때문에, 한 페이지에 20개의 게시글이 있으면 댓글 수 조회 쿼리만 20번 추가 실행됩니다.

```java
// 수정 전 — 게시글 수(N)만큼 쿼리 발생
return page.map(community -> {
    long commentCount =
        commentRepository.countByCommunityId(community.getCommunityId()); // N번 호출
    return MyLikedCommunityResponse.of(community, community.getLikeCount(), commentCount);
});
```

## 해결

이미 `CommunityUseCaseImpl.getMyCommunities`에서 동일한 문제를 배치 쿼리로 해결한 패턴이 존재합니다.
`getMyLikedCommunities`에도 동일한 방식을 적용하여 N번 쿼리를 1번으로 줄였습니다.

```java
// 수정 후 — 배치 조회 1번으로 해결
List<Long> communityIds = page.getContent().stream()
    .map(Community::getCommunityId).toList();
Map<Long, Long> commentCounts = commentRepository.countByCommunityIds(communityIds);

return page.map(community -> {
    long commentCount = commentCounts.getOrDefault(community.getCommunityId(), 0L);
    return MyLikedCommunityResponse.of(community, community.getLikeCount(), commentCount);
});
```

## 테스트

`LikeUseCaseImplTest.getMyLikedCommunities` 테스트를 배치 방식에 맞게 교체했습니다.

| 테스트 케이스 | 검증 내용 |
|---|---|
| `latestSort_usesBatchCommentCount` | 배치 메서드(`countByCommunityIds`) 호출 확인, 단건 메서드(`countByCommunityId`) 미호출(`never()`) 확인, commentCount 정상 매핑 확인 |
| `popularSort_usesBatchCommentCount` | 정렬 방식과 무관하게 배치 쿼리 사용 확인 |
| `emptyPage_callsBatchWithEmptyList` | 결과 없을 때 빈 리스트로 배치 호출되는지 확인 |
| `missingCommentCountEntry_defaultsToZero` | Map에 해당 ID가 없을 때 0으로 기본값 처리 확인 |

## 변경 파일

- `application/community/usecase/LikeUseCaseImpl.java`
- `test/.../usecase/LikeUseCaseImplTest.java`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized comment count loading when viewing your liked communities, improving page load performance.
  * Enhanced robustness by ensuring missing comment counts gracefully default to zero.

* **Tests**
  * Expanded test coverage for comment retrieval functionality and edge case scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->